### PR TITLE
Allow description to have backticks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -3,7 +3,7 @@ var marked = require('marked');
 var unhtml = require('unhtml');
 
 var allElements = [
-  'code', 'blockquote', 'html', 'codespan', 'strong', 'em', 'br', 'del',
+  'blockquote', 'html', 'strong', 'em', 'br', 'del',
   'heading', 'hr', 'image', 'link', 'list', 'listitem',
   'paragraph', 'strikethrough', 'table', 'tablecell', 'tablerow'
 ];
@@ -25,7 +25,14 @@ exports.parse = function(markdown) {
 
   // paragraphs just pass through (automatically created by new lines)
   r.paragraph = function(text) {
-    return text;
+    if (/^<code>.*<\/code>$/.test(text)) {
+      var example = _.last(page.examples);
+      if (example) {
+        example.code = unhtml(text);
+      }
+    } else {
+      return text;
+    }
   };
 
   r.heading = function(text, level) {
@@ -43,14 +50,7 @@ exports.parse = function(markdown) {
     _.last(page.examples).description = unhtml(text);
   };
 
-  r.codespan = function(code, lang) {
-    var example = _.last(page.examples);
-    if (example) {
-      example.code = unhtml(code);
-    }
-  };
-
-  marked(markdown, {renderer: r});
+  marked(markdown, {renderer: r, sanitize: true});
 
   page.examples = page.examples.filter(function(example) {
     return example.description && example.code;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -44,7 +44,10 @@ exports.parse = function(markdown) {
   };
 
   r.codespan = function(code, lang) {
-    _.last(page.examples).code = unhtml(code);
+    var example = _.last(page.examples);
+    if (example) {
+      example.code = unhtml(code);
+    }
   };
 
   marked(markdown, {renderer: r});

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -87,4 +87,29 @@ describe('Parser', function() {
     page.examples.should.have.length(1);
   });
 
+  it('should parse description with inline code', function() {
+    var page = parser.parse(
+      '\n# uname' +
+      '\n> See also `lsb_release`'
+    );
+    page.description.should.eql('See also lsb_release');
+  });
+
+  it('should parse examples with inline code', function() {
+    var page = parser.parse(
+      '\n# uname' +
+      '\n> See also' +
+      '\n' +
+      '\n- example 1, see `inline_cmd1` for details' +
+      '\n' +
+      '\n`cmd1 --foo`' +
+      '\n' +
+      '\n- example 2, see `inline_cmd2` for details' +
+      '\n' +
+      '\n`cmd2 --foo`'
+    );
+    page.examples[0].description.should.eql('example 1, see inline_cmd1 for details');
+    page.examples[1].description.should.eql('example 2, see inline_cmd2 for details');
+  });
+
 });


### PR DESCRIPTION
Fix #17

The issue happened because description contained backticks.

The following page make the client to fail before this PR:

~~~Markdown
# git

> Main command for all `git` commands

- Check the Git version

`git --version`

- Call general help

`git --help`

- Call help on a command

`git help {{COMMAND}}`

- Execute Git command

`git {{COMMAND}}`
~~~

To test it:

- copy paste Markdown from here
- save to some file
- run with `--render myfile.md`