### PR TITLE
Fix #15: upgrade commander to 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "colors": "~1.0.1",
-    "commander": "~2.3.0",
+    "commander": "~2.9.0",
     "cpr": "~0.3.2",
     "deep-extend": "~0.2.8",
     "lodash": "~2.4.1",


### PR DESCRIPTION
The problem is related to bug in `commander` package
https://github.com/tj/commander.js/issues/248

It was fixed in 2.4.0 of `commander`. See their [History](https://github.com/tj/commander.js/blob/master/History.md#240--2014-10-17) for more details.

But I updated the package to 2.9.0, because more than a year came after 2.4.0 was released and there are many bug fixes introduced since then.

I tested it under Node 0.12,  4.1 and 5.1.