### PR TITLE
Display several code lines per one example

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,7 @@ exports.parse = function(markdown) {
     if (/^<code>.*<\/code>$/.test(text)) {
       var example = _.last(page.examples);
       if (example) {
-        example.code = unhtml(text);
+        example.code.push(unhtml(text));
       }
     } else {
       return text;
@@ -46,14 +46,14 @@ exports.parse = function(markdown) {
   };
 
   r.listitem = function(text) {
-    page.examples.push({});
+    page.examples.push({ code: [] });
     _.last(page.examples).description = unhtml(text);
   };
 
   marked(markdown, {renderer: r, sanitize: true});
 
   page.examples = page.examples.filter(function(example) {
-    return example.description && example.code;
+    return example.description && example.code.length > 0;
   });
 
   return page;

--- a/lib/render.js
+++ b/lib/render.js
@@ -15,7 +15,9 @@ exports.toANSI = function(page) {
 
   page.examples.forEach(function(example) {
     output.push('  - ' + example.description[TEXT]);
-    output.push('  ' + highlight(example.code));
+    example.code.forEach(function(codeLine) {
+      output.push('  ' + highlight(codeLine));
+    });
     output.push('');
   });
 

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -46,7 +46,7 @@ describe('Parser', function() {
     );
     page.examples.should.have.length(1);
     page.examples[0].description.should.eql('create an archive');
-    page.examples[0].code.should.eql('tar cf {{file.tar}}');
+    page.examples[0].code[0].should.eql('tar cf {{file.tar}}');
   });
 
   it('does not escape HTML in the examples either', function() {
@@ -57,7 +57,7 @@ describe('Parser', function() {
     );
     page.examples.should.have.length(1);
     page.examples[0].description.should.eql('this & that');
-    page.examples[0].code.should.eql('cmd & data');
+    page.examples[0].code[0].should.eql('cmd & data');
   });
 
   it('parses all the examples', function() {
@@ -110,6 +110,31 @@ describe('Parser', function() {
     );
     page.examples[0].description.should.eql('example 1, see inline_cmd1 for details');
     page.examples[1].description.should.eql('example 2, see inline_cmd2 for details');
+  });
+
+  it('should parse several code snippets per one example', function() {
+    var page = parser.parse(
+      '\n- example 1' +
+      '\n' +
+      '\n`cmd1 --foo1`' +
+      '\n' +
+      '\n`cmd1 --foo2`' +
+      '\n' +
+      '\n- example 2' +
+      '\n' +
+      '\n`cmd2 --foo1`' +
+      '\n' +
+      '\n`cmd2 --foo2`' +
+      '\n' +
+      '\n`cmd2 --foo3`'
+    );
+    page.examples[0].code.should.have.length(2);
+    page.examples[0].code[0].should.eql('cmd1 --foo1');
+    page.examples[0].code[1].should.eql('cmd1 --foo2');
+    page.examples[1].code.should.have.length(3);
+    page.examples[1].code[0].should.eql('cmd2 --foo1');
+    page.examples[1].code[1].should.eql('cmd2 --foo2');
+    page.examples[1].code[2].should.eql('cmd2 --foo3');
   });
 
 });

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -37,7 +37,9 @@ describe('Render', function() {
       description: 'archive utility',
       examples: [{
         description: 'create',
-        code: 'hello {{token}} bye'
+        code: [
+          'hello {{token}} bye'
+        ]
       }]
     });
     text.should.containEql('hello '.blackBG.red);


### PR DESCRIPTION
Try `tldr cal`.

Before
```
  cal
  Prints calendar information

  - Display a calendar for the current month or specified month
    cal -m Dec

  - Display a calendar for the current year or a specified year
    cal 2013

  - Display date of Easter (western churches)
    ncal -e 2013
```

After
```
  cal
  Prints calendar information

  - Display a calendar for the current month or specified month
    cal
    cal -m 12
    cal -m Dec

  - Display a calendar for the current year or a specified year
    cal -y
    cal 2013

  - Display date of Easter (western churches)
    ncal -e
    ncal -e 2013
```