### PR TITLE
Improve tests running

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "start": "NODE_ENV=development node server.js",
     "example": "NODE_ENV=development node ./bin/tldr tar",
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha test --recursive --reporter=spec",
+    "watch": "mocha --watch test --recursive --reporter=min --growl"
   },
   "os": [
     "!win32"


### PR DESCRIPTION
Do not use exact path, because `npm test` will figure out the right path to node_modules.

Also add helper `npm run watch`. To make it work on OSX run `brew install terminal-notifier`