### PR TITLE
Undeprecate overriding the operating system

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -15,15 +15,12 @@ program
   .option('-r, --random', 'Show a random command')
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
+  .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos]')
   //
   // CACHE MANAGEMENT
   //
   .option('-u, --update', 'Update the local cache')
-  .option('-c, --clear-cache', 'Clear the local cache')
-  //
-  // DEPRECATED SOON
-  //
-  .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos]');
+  .option('-c, --clear-cache', 'Clear the local cache');
 
 program.on('--help', function() {
   console.log('Examples');
@@ -45,6 +42,14 @@ program.on('--help', function() {
 });
 
 program.parse(process.argv);
+
+if (program.os) {
+  var config = require('../lib/config');
+  var platform = require('../lib/platform');
+  if (platform.isSupported(program.os)) {
+    config.get().platform = program.os;
+  }
+}
 
      if (program.list)              tldr.list();
 else if (program.random)            tldr.random();

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,9 +4,6 @@ var path   = require('path');
 var ms     = require('ms');
 var extend = require('deep-extend');
 
-var DEFAULT  = path.join(__dirname, '..', 'config.json');
-var CUSTOM = path.join(process.env['HOME'], '.tldrrc');
-
 var config = null;
 
 exports.reset = function() {
@@ -19,6 +16,8 @@ exports.get = function() {
 };
 
 function load() {
+  var DEFAULT  = path.join(__dirname, '..', 'config.json');
+  var CUSTOM = path.join(process.env['HOME'], '.tldrrc');
   var defaultConfig = JSON.parse(fs.readFileSync(DEFAULT));
   defaultConfig.cache = path.join(process.env['HOME'], '.tldr');
   defaultConfig.proxy = process.env.HTTP_PROXY || process.env.http_proxy;
@@ -31,11 +30,20 @@ function load() {
 
   var merged = extend(defaultConfig, customConfig);
   var errors = _.map(merged.colors, validateColor);
+  errors.push(validatePlatform(merged.platform));
+  errors = _.compact(errors);
 
-  if (_.compact(errors).length === 0) {
+  if (errors.length === 0) {
     return merged;
   } else {
     throw new Error('Error in .tldrrc configuration:\n' + errors.join('\n'));
+  }
+}
+
+function validatePlatform(os) {
+  var platform = require('./platform');
+  if (os && !platform.isSupported(os)) {
+    return 'Unsupported platform : ' + os;
   }
 }
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,18 +1,39 @@
 var os      = require('os');
+var config  = require('./config');
 
 var folders = {
-  darwin: 'osx',
-  linux : 'linux',
-  sunos : 'sunos'
+  'osx': 'osx',
+  'darwin': 'osx',
+  'linux': 'linux',
+  'sunos': 'sunos'
 };
 
-exports.resolve = function(command) {
-  return [
-    specific(command, folders[os.platform()]),
-    specific(command, 'common')
-  ];
-};
+function isSupported(platform) {
+  return folders.hasOwnProperty(platform);
+}
+
+function getPreferredPlatform() {
+  var platform = config.get().platform;
+  if (isSupported(platform)) {
+    return platform;
+  }
+  return os.platform();
+}
 
 function specific(command, os) {
   return 'pages/' + os + '/' + command + '.md';
 }
+
+function resolve(command) {
+  var platform = getPreferredPlatform();
+  return [
+    specific(command, folders[platform]),
+    specific(command, 'common')
+  ];
+}
+
+module.exports = {
+  isSupported: isSupported,
+  getPreferredPlatform: getPreferredPlatform,
+  resolve: resolve
+};

--- a/test/platform.spec.js
+++ b/test/platform.spec.js
@@ -1,0 +1,62 @@
+var os     = require('os');
+var config = require('../lib/config');
+var sinon  = require('sinon');
+var should = require('should');
+var platform = require('../lib/platform')
+
+describe('Platform', function() {
+
+  describe('getPreferredPlatform', function() {
+    beforeEach(function() {
+      sinon.stub(os, 'platform');
+      sinon.stub(config, 'get');
+    });
+
+    afterEach(function() {
+      os.platform.restore();
+      config.get.restore();
+    });
+
+    it('should return the running platform with no configuration', function() {
+      os.platform.onCall(0).returns('darwin');
+      config.get.onCall(0).returns({});
+      platform.getPreferredPlatform().should.eql('darwin');
+    });
+
+    it('should overwrite the running platform if configured', function() {
+      os.platform.onCall(0).returns('darwin');
+      config.get.onCall(0).returns({
+        platform: 'linux'
+      });
+      platform.getPreferredPlatform().should.eql('linux');
+    });
+  });
+
+  describe('isSupported', function() {
+    it('should tell that Linux, OSX and SunOS are supported', function() {
+      platform.isSupported('osx').should.eql(true);
+      platform.isSupported('linux').should.eql(true);
+      platform.isSupported('sunos').should.eql(true);
+      platform.isSupported('windows').should.eql(false); // Yet
+      platform.isSupported('ios').should.eql(false);
+    });
+  });
+
+  describe('resolve', function() {
+    beforeEach(function() {
+      sinon.stub(os, 'platform');
+    });
+
+    afterEach(function() {
+      os.platform.restore();
+    });
+
+    it('should resolve tar command with specific OS and common folder', function() {
+      os.platform.onCall(0).returns('linux');
+      platform.resolve('tar').should.eql([
+        'pages/linux/tar.md',
+        'pages/common/tar.md',
+      ]);
+    });
+  });
+});

--- a/test/platform.spec.js
+++ b/test/platform.spec.js
@@ -30,6 +30,14 @@ describe('Platform', function() {
       });
       platform.getPreferredPlatform().should.eql('linux');
     });
+
+    it('should return current system platform if configuration is wrong', function() {
+      os.platform.onCall(0).returns('darwin');
+      config.get.onCall(0).returns({
+        platform: 'there_is_no_such_platform'
+      });
+      platform.getPreferredPlatform().should.eql('darwin');
+    });
   });
 
   describe('isSupported', function() {


### PR DESCRIPTION
Consider the following use cases:

- User works as a system administrator on Windows or OSX machine, but they are managing Linux servers. They cannot install tldr everywhere, so they run it on their machine but they want to search command syntax for target platform.
- User is using his mobile device - Android or iOS (there is no iOS client yet, but it can be created soon with existing code and PhoneGap technology). They want to check command syntax for their Linux/OSX laptop.

Using this patch they can configure platform in `$HOME/.tldrrc`:

~~~json
{
  "platform": "linux"
}
~~~

Or in command line:

`tldr du --os=linux`