### PR TITLE
Move static site url from code to configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "url": "http://tldr-pages.github.io/assets/tldr.zip",
   "colors": {
     "text": "green",
     "command-background": "black",

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -17,7 +17,7 @@ if (config.get().proxy) {
 
 exports.download = function(done) {
   var src = source();
-  var url = 'http://tldr-pages.github.io/assets/tldr.zip';
+  var url = config.get().url;
   var target = path.join(os.tmpdir(), 'tldr');
   var inside = target;
   if (src) {


### PR DESCRIPTION
Currently URL to static site is hardcoded.

It is OK for now, but moving it to configuration gives the following benefits:

- redeclare this URL in `$HOME/.tldrrc` file
- allow to move away from static site and migrate to AWS S3, CDN or other type of distribution
- allow to use several pages archives at the moment and easily switch between them, i.e. tldr-latest.zip, tldr-stable.zip