### PR TITLE
Fix issue with 'page not found message'

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "pagesRepository": "tldr-pages/tldr",
   "colors": {
     "text": "green",
     "command-background": "black",

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -8,5 +8,5 @@ exports.emptyCache = function() {
 exports.notFound = function() {
   return 'Page not found\n' +
   'Try updating with "tldr --update", or submit a pull request to:\n' +
-  'http://github.com/' + config.get().repository;
+  'https://github.com/' + config.get().pagesRepository;
 };


### PR DESCRIPTION
Currently if you run 
`$tldr qwerty`

It shows the following message:
```
Page not found
Try updating with "tldr --update", or submit a pull request to:
http://github.com/undefined
```

This PR:
- introduces pagesRepository config option
- points it to tldr-pages/tldr Github repo
- uses it in lib/message.js

