### PR TITLE
re #44 add option to output all data

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -16,6 +16,7 @@ program
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
   .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos]')
+  .option('-a, --all', 'Show tl;dr for all commands in the cache')
   //
   // CACHE MANAGEMENT
   //
@@ -29,6 +30,7 @@ program.on('--help', function() {
   console.log('    $ tldr --list');
   console.log('    $ tldr --random');
   console.log('    $ tldr --random-example');
+  console.log('    $ tldr --all');
   console.log('');
   console.log('To control the cache');
   console.log('');
@@ -63,6 +65,8 @@ if (program.list) {
   tldr.updateCache();
 } else if (program.render) {
   tldr.render(program.render);
+} else if (program.all) {
+  tldr.all();
 } else if (program.args.length == 1) {
   tldr.get(program.args[0], program);
 } else {

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -77,6 +77,20 @@ exports.updateCache = function() {
   });
 };
 
+exports.all = function() {
+  if (cache.lastUpdate) {
+    console.log('Cache last updated', cache.lastUpdate);
+  }
+
+  cache.list(function(err, pages) {
+    if (err) {
+      console.error(messages.emptyCache());
+      exit(1);
+    }
+    checkStale();
+    pages.map(function(page) { return [page]; }).forEach(printBestPage);
+  });
+};
 
 
 function printBestPage(pages, options) {


### PR DESCRIPTION
see issue #44 
I thought I would run exports.get on every result from cache.list, but then I resorted to just `printBestPage` even if it's not in the platform.

Now you can run `tldr --all > all` to have a file with all data or `tldr --all | less` to see it in the terminal. Colors are lost, though :(