### PR TITLE
Performance improvement: 

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,18 +1,13 @@
-var request = require('request');
 var path    = require('path');
 var os      = require('os');
-var unzip   = require('unzip2');
 var mkdirp  = require('mkdirp');
 var rimraf  = require('rimraf');
 var config  = require('./config');
 
-if (config.get().proxy) {
-  request = request.defaults({
-    'proxy':config.proxy
-  });
-}
 
 exports.download = function(done) {
+  var request = require('request');
+  var unzip   = require('unzip2');
   var src = source();
   var url = config.get().url;
   var target = path.join(os.tmpdir(), 'tldr');
@@ -32,6 +27,12 @@ exports.download = function(done) {
   extractor.on('close', function() {
     done(null, inside);
   });
+
+  if (config.get().proxy) {
+    request = request.defaults({
+      'proxy':config.proxy
+    });
+  }
 
   var req = request.get({
     url: url,


### PR DESCRIPTION
It loads modules request and unzip2 only on demand.
See discussion on #49.

Thanks for investigation, profiling, idea to @amitzur and @VarunAgw.

Dev version of tldr runs 500-600 ms with this patch comparing to 900-1000ms without it. So it is approximately 40% faster.