### PR TITLE
Don't highlight random options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ To see tldr pages:
 
 - `tldr <command>` show examples for this command
 - `tldr --list` show all available pages
-- `tldr --random` show a page at random
-- `tldr --random-example` show a single random example
 
 The client caches a copy of all pages locally, in `~/.tldr`.
 There are more commands to control the local cache:
@@ -57,7 +55,7 @@ As a contributor, you can also point to your own fork or branch:
 {
   "repository" : "myfork/tldr",
   // or
-  "repository" : "myfork/tldr#mybranch",  
+  "repository" : "myfork/tldr#mybranch",
 }
 ```
 

--- a/bin/tldr
+++ b/bin/tldr
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
-var util    = require('util');
 var tldr    = require('../lib/tldr');
 var pkg     = require('../package');
 var program = require('commander');
 
 program
   .version(pkg.version)
-  .usage('commandName [options]')
+  .usage('command_name [options]')
   //
   // BASIC OPTIONS
   //
@@ -27,8 +26,6 @@ program.on('--help', function() {
   console.log('');
   console.log('    $ tldr tar');
   console.log('    $ tldr --list');
-  console.log('    $ tldr --random');
-  console.log('    $ tldr --random-example');
   console.log('');
   console.log('To control the cache');
   console.log('');
@@ -66,6 +63,6 @@ if (program.list) {
 } else if (program.args.length == 1) {
   tldr.get(program.args[0], program);
 } else {
-  util.log('Usage: tldr <command>');
+  program.help();
   process.exit(1);
 }


### PR DESCRIPTION
`--random`, `--random-example` options are not the most usable commands.

I removed them from README and help text. They are still listed on help page and works. We just not push users to use them.