### PR TITLE
Use lodash function instead of deep-extend package

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,6 @@
 var _         = require('lodash');
 var fs        = require('fs');
 var path      = require('path');
-var extend    = require('deep-extend');
 var osHomedir = require('os-homedir');
 
 var config = null;
@@ -30,7 +29,7 @@ function load() {
     /*eslint-enable */
   }
 
-  var merged = extend(defaultConfig, customConfig);
+  var merged = _.defaultsDeep(customConfig, defaultConfig);
   var errors = _.map(merged.colors, validateColor);
   errors.push(validatePlatform(merged.platform));
   errors = _.compact(errors);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "colors": "~1.1.2",
     "commander": "~2.9.0",
     "cpr": "~1.0.0",
-    "deep-extend": "~0.4.0",
     "lodash": "~3.10.1",
     "marked": "~0.3.5",
     "mkdirp": "~0.5.1",


### PR DESCRIPTION
Remove deep-extend as this functionality is already available in lodash.