### PR TITLE
List options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ npm install -g tldr
 To see tldr pages:
 
 - `tldr <command>` show examples for this command
+- `tldr <command> --os=linux` show page for Linux version of this command
 - `tldr --list` show all available pages
 - `tldr --random` show a page at random
 - `tldr --random-example` show a single random example
@@ -49,6 +50,20 @@ This file has to be valid JSON:
     "command-token": "white"
   }
 }
+```
+
+If you need to always read pages for different platform (e.g. Linux), you can put it in config file:
+
+```json
+{
+  "platform": "linux"
+}
+```
+
+The default platform value can be overwritten with command-line option:
+
+```shell
+tldr du --os=osx
 ```
 
 As a contributor, you can also point to your own fork or branch:

--- a/bin/tldr
+++ b/bin/tldr
@@ -11,7 +11,8 @@ program
   //
   // BASIC OPTIONS
   //
-  .option('-l, --list', 'List all commands in the cache')
+  .option('-l, --list', 'List all commands for the chosen platform in the cache')
+  .option('-a, --list-all', 'List all commands in the cache')
   .option('-r, --random', 'Show a random command')
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
@@ -54,6 +55,8 @@ if (program.os) {
 
 if (program.list) {
   tldr.list();
+} else if (program.listAll) {
+  tldr.listAll();
 } else if (program.random) {
   tldr.random();
 } else if (program.randomExample) {

--- a/bin/tldr
+++ b/bin/tldr
@@ -13,6 +13,7 @@ program
   //
   .option('-l, --list', 'List all commands for the chosen platform in the cache')
   .option('-a, --list-all', 'List all commands in the cache')
+  .option('-1, --single-column', 'List single command per line (use with options -l or -a)')
   .option('-r, --random', 'Show a random command')
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
@@ -54,9 +55,9 @@ if (program.os) {
 }
 
 if (program.list) {
-  tldr.list();
+  tldr.list(program.singleColumn);
 } else if (program.listAll) {
-  tldr.listAll();
+  tldr.listAll(program.singleColumn);
 } else if (program.random) {
   tldr.random();
 } else if (program.randomExample) {

--- a/bin/tldr
+++ b/bin/tldr
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var util    = require('util');
 var tldr    = require('../lib/tldr');
 var pkg     = require('../package');
 var program = require('commander');
@@ -67,6 +66,6 @@ if (program.list) {
 } else if (program.args.length == 1) {
   tldr.get(program.args[0], program);
 } else {
-  util.log('Usage: tldr <command>');
+  program.outputHelp();
   process.exit(1);
 }

--- a/bin/tldr
+++ b/bin/tldr
@@ -26,6 +26,7 @@ program.on('--help', function() {
   console.log('Examples');
   console.log('');
   console.log('    $ tldr tar');
+  console.log('    $ tldr du --os=linux');
   console.log('    $ tldr --list');
   console.log('    $ tldr --random');
   console.log('    $ tldr --random-example');

--- a/bin/tldr
+++ b/bin/tldr
@@ -6,7 +6,8 @@ var program = require('commander');
 
 program
   .version(pkg.version)
-  .usage('commandName [options]')
+  .description(pkg.description)
+  .usage('command [options]')
   //
   // BASIC OPTIONS
   //

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,14 +3,15 @@ var path      = require('path');
 var rmdir     = require('rimraf');
 var cpr       = require('cpr');
 var wrench    = require('wrench');
+var _         = require('lodash');
 var config    = require('./config');
 var remote    = require('./remote');
+var platform  = require('./platform');
 
 var CACHE_FOLDER = path.join(config.get().cache, 'cache');
 
 // It's OK to read it on startup
 exports.lastUpdate = lastUpdate();
-
 
 exports.get = function(potentialPages, done) {
   tryLoad(potentialPages, 0, function(err, contents) {
@@ -19,15 +20,24 @@ exports.get = function(potentialPages, done) {
   });
 };
 
-exports.list = function(done) {
+exports.list = function(os, done) {
   var files;
+  if (os && !platform.isSupported(os)) {
+    return done(new Error('Platform ' + os + ' is not supported'));
+  }
+  var pagesPath = path.join(CACHE_FOLDER, 'pages');
   try {
-    files = wrench.readdirSyncRecursive(CACHE_FOLDER);
+    files = wrench.readdirSyncRecursive(pagesPath);
   } catch (ex) {
     /*eslint-disable */
     /*eslint-enable */
   }
-  if (!files) return done(new Error('Cache unavailable'));
+  if (!files) {
+    return done(new Error('Cache unavailable'));
+  }
+  if (os) {
+    files = files.filter(onPlatform(os));
+  }
   var pages = files.filter(isPage).sort();
   done(null, pages);
 };
@@ -62,9 +72,14 @@ function tryLoad(pages, index, done) {
 }
 
 function isPage(file) {
-  return file.match(/pages\/.*\.md$/);
+  return file.match(/.*\.md$/);
 }
 
+function onPlatform(os) {
+  return function(file) {
+    return _.startsWith(file, 'common') || _.startsWith(file, os);
+  };
+}
 
 function lastUpdate() {
   try {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,6 @@
 var _         = require('lodash');
 var fs        = require('fs');
 var path      = require('path');
-var extend    = require('deep-extend');
 var osHomedir = require('os-homedir');
 
 var config = null;
@@ -30,7 +29,7 @@ function load() {
     /*eslint-enable */
   }
 
-  var merged = extend(defaultConfig, customConfig);
+  var merged = _.defaultsDeep(customConfig, defaultConfig);
   var errors = _.map(merged.colors, validateColor);
   errors.push(validatePlatform(merged.platform));
   errors = _.compact(errors);

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -26,15 +26,20 @@ function specific(command, os) {
 }
 
 function resolve(command) {
-  var platform = getPreferredPlatform();
   return [
-    specific(command, folders[platform]),
+    specific(command, getPreferredPlatformFolder()),
     specific(command, 'common')
   ];
+}
+
+function getPreferredPlatformFolder() {
+  var platform = getPreferredPlatform();
+  return folders[platform];
 }
 
 module.exports = {
   isSupported: isSupported,
   getPreferredPlatform: getPreferredPlatform,
+  getPreferredPlatformFolder: getPreferredPlatformFolder,
   resolve: resolve
 };

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,18 +1,13 @@
-var request = require('request');
 var path    = require('path');
 var os      = require('os');
-var unzip   = require('unzip2');
 var mkdirp  = require('mkdirp');
 var rimraf  = require('rimraf');
 var config  = require('./config');
 
-if (config.get().proxy) {
-  request = request.defaults({
-    'proxy':config.proxy
-  });
-}
 
 exports.download = function(done) {
+  var request = require('request');
+  var unzip   = require('unzip2');
   var src = source();
   var url = config.get().url;
   var target = path.join(os.tmpdir(), 'tldr');
@@ -32,6 +27,12 @@ exports.download = function(done) {
   extractor.on('close', function() {
     done(null, inside);
   });
+
+  if (config.get().proxy) {
+    request = request.defaults({
+      'proxy':config.proxy
+    });
+  }
 
   var req = request.get({
     url: url,

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -8,7 +8,17 @@ var parser   = require('./parser');
 var render   = require('./render');
 var exit     = process.exit;
 
-exports.list = function() {
+
+function printPages(pages, singleColumn) {
+  var endOfLine = require('os').EOL;
+  var delimiter = ', ';
+  if (singleColumn) {
+    delimiter = endOfLine;
+  }
+  console.log('\n' + pages.map(pageName).join(delimiter));
+}
+
+exports.list = function(singleColumn) {
   cache.list(platform.getPreferredPlatformFolder(), function(err, pages) {
     if (err) {
       console.log(err.message);
@@ -16,11 +26,11 @@ exports.list = function() {
       exit(1);
     }
     checkStale();
-    console.log('\n' + pages.map(pageName).join(', '));
+    printPages(pages, singleColumn);
   });
 };
 
-exports.listAll = function() {
+exports.listAll = function(singleColumn) {
   cache.list('', function(err, pages) {
     if (err) {
       console.log(err.message);
@@ -28,7 +38,7 @@ exports.listAll = function() {
       exit(1);
     }
     checkStale();
-    console.log('\n' + pages.map(pageName).join(', '));
+    printPages(pages, singleColumn);
   });
 };
 

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -9,11 +9,21 @@ var render   = require('./render');
 var exit     = process.exit;
 
 exports.list = function() {
-  if (cache.lastUpdate) {
-    console.log('Cache last updated', cache.lastUpdate);
-  }
-  cache.list(function(err, pages) {
+  cache.list(platform.getPreferredPlatformFolder(), function(err, pages) {
     if (err) {
+      console.log(err.message);
+      console.error(messages.emptyCache());
+      exit(1);
+    }
+    checkStale();
+    console.log('\n' + pages.map(pageName).join(', '));
+  });
+};
+
+exports.listAll = function() {
+  cache.list('', function(err, pages) {
+    if (err) {
+      console.log(err.message);
       console.error(messages.emptyCache());
       exit(1);
     }
@@ -77,8 +87,6 @@ exports.updateCache = function() {
   });
 };
 
-
-
 function printBestPage(pages, options) {
   cache.get(pages, function(err, content) {
     if (err) {
@@ -102,5 +110,5 @@ function checkStale() {
 }
 
 function pageName(file) {
-  return file.match(/pages\/.*\/(.*)\.md$/)[1];
+  return file.match(/.*\/(.*)\.md$/)[1];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldr",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Simplified and community-driven man pages",
   "author": "Romain Prieto",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "precommit": "npm run lint && npm run test:quiet",
     "prepush": "npm run test:quiet",
     "postinstall": "node ./bin/tldr --update",
-    "start": "NODE_ENV=development node ./bin/tldr",
-    "example": "NODE_ENV=development node ./bin/tldr tar",
+    "start": "node ./bin/tldr",
+    "example": "node ./bin/tldr tar",
     "test": "mocha test",
-    "test:quiet": "npm test -- --reporter=dot",
+    "test:quiet": "mocha test --reporter=dot",
     "lint": "eslint lib test bin/tldr",
-    "watch": "npm run test:quiet -- --reporter=min --watch --growl"
+    "watch": "mocha test --reporter=min --watch --growl"
   },
   "dependencies": {
     "async": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "precommit": "npm run lint && npm run test:quiet",
     "prepush": "npm run test:quiet",
+    "postinstall": "node ./bin/tldr --update",
     "start": "NODE_ENV=development node ./bin/tldr",
     "example": "NODE_ENV=development node ./bin/tldr tar",
     "test": "mocha test",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "colors": "~1.1.2",
     "commander": "~2.9.0",
     "cpr": "~1.0.0",
-    "deep-extend": "~0.4.0",
     "lodash": "~3.10.1",
     "marked": "~0.3.5",
     "mkdirp": "~0.5.1",

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -1,0 +1,104 @@
+var wrench = require('wrench');
+var cache = require('../lib/cache');
+var sinon = require('sinon');
+
+describe('Cache', function() {
+
+  describe('list()', function() {
+
+    beforeEach(function() {
+      sinon.stub(wrench, 'readdirSyncRecursive')
+        .returns([
+          'index.json',
+          'linux',
+          'osx',
+          'sunos',
+          'common/a.md',
+          'common/b.md',
+          'common/c.md',
+          'common/d.md',
+          'linux/e.md',
+          'linux/f.md',
+          'linux/g.md',
+          'osx/f.md',
+          'osx/g.md',
+          'sunos/f.md',
+          'sunos/x.md',
+          'sunos/z.md'
+        ]);
+    });
+
+    afterEach(function() {
+      wrench.readdirSyncRecursive.restore();
+    });
+
+    it('should return list of pages supported for OSX', function(done) {
+      cache.list('osx', function(err, files) {
+        files.length.should.eql(6);
+        files.should.deepEqual([
+          'common/a.md',
+          'common/b.md',
+          'common/c.md',
+          'common/d.md',
+          'osx/f.md',
+          'osx/g.md'
+        ]);
+        done();
+      });
+    });
+
+    it('should return list of pages supported for Linux', function(done) {
+      cache.list('linux', function(err, files) {
+        files.length.should.eql(7);
+        files.should.deepEqual([
+          'common/a.md',
+          'common/b.md',
+          'common/c.md',
+          'common/d.md',
+          'linux/e.md',
+          'linux/f.md',
+          'linux/g.md'
+        ]);
+        done();
+      });
+    });
+
+    it('should return list of pages supported for SunOS', function(done) {
+      cache.list('sunos', function(err, files) {
+        files.length.should.eql(7);
+        files.should.deepEqual([
+          'common/a.md',
+          'common/b.md',
+          'common/c.md',
+          'common/d.md',
+          'sunos/f.md',
+          'sunos/x.md',
+          'sunos/z.md'
+        ]);
+        done();
+      });
+    });
+
+    it('should return list of all pages', function(done) {
+      cache.list('', function(err, files) {
+        files.length.should.eql(12);
+        files.should.deepEqual([
+          'common/a.md',
+          'common/b.md',
+          'common/c.md',
+          'common/d.md',
+          'linux/e.md',
+          'linux/f.md',
+          'linux/g.md',
+          'osx/f.md',
+          'osx/g.md',
+          'sunos/f.md',
+          'sunos/x.md',
+          'sunos/z.md'
+        ]);
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
New and updated options:
- `-l` or `--list` - print all commands for default platform
- `-a`, `--list-all` - print all commands for all platforms
- `-1` or `--single-column` - print commands in a single column, has to be used together with `--list` or `--list-all`