### PR TITLE
Fix --list commands on Windows

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -72,7 +72,7 @@ function tryLoad(pages, index, done) {
 }
 
 function isPage(file) {
-  return file.match(/.*\.md$/);
+  return path.extname(file) == '.md';
 }
 
 function onPlatform(os) {

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -1,6 +1,7 @@
 var _        = require('lodash');
 var fs       = require('fs');
 var ms       = require('ms');
+var path     = require('path');
 var cache    = require('./cache');
 var platform = require('./platform');
 var messages = require('./messages');
@@ -122,5 +123,5 @@ function checkStale() {
 }
 
 function pageName(file) {
-  return file.match(/.*\/(.*)\.md$/)[1];
+  return path.basename(file, '.md');
 }


### PR DESCRIPTION
- Use module path instead of regular expressions