### PR TITLE
See also

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,7 @@
 var last = require('lodash.last');
 var unescape = require('lodash.unescape');
 var marked = require('marked');
+var index = require('./index');
 
 var allElements = [
   'blockquote', 'html', 'strong', 'em', 'br', 'del',
@@ -9,7 +10,7 @@ var allElements = [
 ];
 
 function unhtml(text){
-  text = text.replace(/<code>/, '').replace(/<\/code>/, '');
+  // text = text.replace(/<code>/, '').replace(/<\/code>/, '');
   return unescape(text);
 }
 
@@ -18,7 +19,8 @@ exports.parse = function(markdown) {
   var page = {
     name: '',
     description: '',
-    examples: []
+    examples: [],
+    seeAlso: []
   };
 
   var r = new marked.Renderer();
@@ -28,33 +30,59 @@ exports.parse = function(markdown) {
     r[e] = function() { return ''; };
   });
 
-  // paragraphs just pass through (automatically created by new lines)
-  r.paragraph = function(text) {
-    if (/^<code>.*<\/code>$/.test(text)) {
-      var example = last(page.examples);
-      if (example) {
-        example.code = unhtml(text);
+  r.codespan = function(text) {
+    if (index.hasPage(text) && text !== page.name) {
+      if (page.seeAlso.indexOf(text) < 0) {
+        page.seeAlso.push(text);
       }
+    }
+    var example = last(page.examples);
+    if (example) {
+      example.code = unhtml(text);
     }
     return text;
   };
+
+
+  // paragraphs just pass through (automatically created by new lines)
+  r.paragraph = function(text) {
+    // if (/^<code>.*<\/code>$/.test(text)) {
+    //   var example = _.last(page.examples);
+    //   if (example) {
+    //     example.code = unhtml(text);
+    //   }
+    // } else {
+    return text;
+    // }
+  };
+
+  // r.paragraph = function(text) {
+  //   return text;
+  // };
 
   r.heading = function(text, level) {
     if (level === 1) {
       page.name = text.trim();
     }
+    return text;
   };
 
   r.blockquote = function(text) {
     page.description += unhtml(text);
+    return text;
   };
 
   r.listitem = function(text) {
-    page.examples.push({});
-    last(page.examples).description = unhtml(text);
+    page.examples.push({
+      description: unhtml(text)
+    });
+    return text;
   };
 
-  marked(markdown, {renderer: r, sanitize: true});
+  marked(markdown, {
+    renderer: r,
+    sanitize: true
+  });
 
   page.examples = page.examples.filter(function(example) {
     return example.description && example.code;

--- a/lib/render.js
+++ b/lib/render.js
@@ -21,6 +21,16 @@ exports.toANSI = function(page) {
     output.push('');
   });
 
+  if (page.seeAlso && page.seeAlso.length > 0) {
+    output.push('');
+    output.push('See also:');
+    page.seeAlso.forEach(function(command) {
+      output.push('  - ' + command);
+      output.push('');
+    });
+    output.push('');
+  }
+
   return '\n' + output.join('\n') + '\n';
 };
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -23,11 +23,7 @@ exports.toANSI = function(page) {
 
   if (page.seeAlso && page.seeAlso.length > 0) {
     output.push('');
-    output.push('See also:');
-    page.seeAlso.forEach(function(command) {
-      output.push('  - ' + command);
-      output.push('');
-    });
+    output.push('See also: ' + page.seeAlso.join(', '));
     output.push('');
   }
 

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -47,4 +47,21 @@ describe('Render', function() {
     text.should.containEql(' bye'.blackBG.red);
   });
 
+  it('should correctly render see also section', function() {
+    var text = render.toANSI({
+      name: 'uname',
+      description: 'Description for `uname`.\n' +
+                   'See also `lsb_release`.',
+      examples: [{
+        description: '1st example. You need `sudo` to run this',
+        code: 'uname {{token}}'
+      }],
+      seeAlso: [
+        'lsb_release',
+        'sudo'
+      ]
+    });
+    text.should.containEql('See also: lsb_release, sudo');
+  });
+
 });


### PR DESCRIPTION
It parses all other commands in backticks. If they are in the index, then it renders them additionally in "See Also" section in the end.

Note: this is not real command description

```md
# uname
> Print details about the current machine and the operating system running on it.
> Note: If you're on Linux, try also the `lsb_release` command.

- Print hardware-related information: machine and processor (see `ln`):

`uname -mp`

- Print operating system, release number, and version (see `lsb_release`):

`uname -srv`

- Print all available system information (hardware, software, nodename), see `ls`:

`uname -a`
```

It will give the following output. Take a look on See Also section at the end.

```bash
$ tldr uname

  uname
  Print details about the current machine and the operating system running on it.
  Note: If you're on Linux, try also the lsb_release command.

  - Print hardware-related information: machine and processor (see ln):
    uname -mp

  - Print operating system, release number, and version (see lsb_release):
    uname -srv

  - Print all available system information (hardware, software, nodename), see ls:
    uname -a


See also:
  - lsb_release
  - ln
  - ls
```