### PR TITLE
AppVeyor: adding LTS and Stable NodeJS versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4.0"
     - nodejs_version: "4.1"
+    - nodejs_version: LTS
+    - nodejs_version: Stable
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Adding 2 NodeJS versions for AppVeyor build:
-  LTS (4.3 at the moment)
- Stable (5.5 at the moment)