### PR TITLE
Specify files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
     "node": ">=0.10"
   },
   "main": "./bin/tldr",
+    "files": [
+    "autocompletion",
+    "bin",
+    "config.json",
+    "lib",
+    "LICENSE.md"
+  ],
   "bin": {
     "tldr": "./bin/tldr"
   },

--- a/test/theme.spec.js
+++ b/test/theme.spec.js
@@ -3,7 +3,7 @@ var chalk = require('chalk');
 
 describe('Theme', function() {
 
-  describe('Redering', function() {
+  describe('Rendering', function() {
 
     var theme = new Theme({
       name: 'green, bold',


### PR DESCRIPTION
As discussed in #96.

The installed directory seems fine:
```bash
$ ls node_modules/tldr/
autocompletion  bin  config.json  lib  LICENSE.md  package.json  README.md
```