### PR TITLE
Fix the README to a better way of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install -g tldr
 If you are installing with sudo, pass the `--user` parameter:
 
 ```bash
-sudo npm install -g tldr --user=<logged_in_user>
+sudo npm install -g tldr --user=$(whoami)
 ```
 
 This is required because we populate the page cache after installation. And npm by default downgrades the post-install user permission level to `nobody` when run as root.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ A `Node.js` based command-line client for [tldr](https://github.com/tldr-pages/t
 npm install -g tldr
 ```
 
-If you have trouble with the post-install script, try the following commands:
+If you are installing with sudo, pass the `--user` parameter:
 
 ```bash
-npm install -g --ignore-scripts tldr
-tldr --update
+sudo npm install -g tldr --user=<logged_in_user>
 ```
+
+This is required because we populate the page cache after installation. And npm by default downgrades the post-install user permission level to `nobody` when run as root.
 
 ## Usage
 


### PR DESCRIPTION
Asking the user to pass `--ignore-scripts` and then doing `tldr --update` does not look very elegant. A better way is to pass the `--user` variable which will let npm use that user permission while executing the postinstall script. 

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary

