### PR TITLE
Simplify package.json (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Romain Prieto",
   "license": "MIT",
   "repository": "tldr-pages/tldr-node-client",
-  "bugs": "https://github.com/tldr-pages/tldr-node-client/issues",
   "keywords": [
     "man",
     "unix",
@@ -21,7 +20,7 @@
   "engines": {
     "node": ">=0.10"
   },
-  "main": "./bin/tldr",
+  "main": "bin/tldr",
   "files": [
     "bin",
     "config.json",


### PR DESCRIPTION
1. [normalize-package-data](https://github.com/npm/normalize-package-data#what-normalization-currently-entails) says bugs are needless if you're specified the repository.
2. `main` is supposed to be relative to current directory so `./` is needless too.