### PR TITLE
Removing postinstall step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,8 @@ A `Node.js` based command-line client for [tldr](https://github.com/tldr-pages/t
 ## Installing
 
 ```bash
-npm install -g tldr
+sudo npm install -g tldr
 ```
-
-If you are installing with sudo, pass the `--user` parameter:
-
-```bash
-sudo npm install -g tldr --user=$(whoami)
-```
-
-This is required because we populate the page cache after installation. And npm by default downgrades the post-install user permission level to `nobody` when run as root.
-
 ## Usage
 
 To see tldr pages:

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -108,10 +108,28 @@ function printPages(pages, singleColumn) {
 function printBestPage(command, options) {
   var content = cache.getPage(command);
   if (!content) {
-    console.error(messages.notFound());
-    exit(1);
+    console.log('Page not found. Updating cache ..');
+    cache.update(function(err) {
+      if (err) {
+        console.error(err.stack);
+        exit(1);
+      }
+      var content2 = cache.getPage(command);
+      if (!content2) {
+        console.error(messages.notFound());
+        exit(1);
+      } else {
+        checkStale();
+        renderContent(content2, options);
+      }
+    });
+  } else {
+    checkStale();
+    renderContent(content, options);
   }
-  checkStale();
+}
+
+function renderContent(content, options) {
   var page = parser.parse(content);
   if (options && options.randomExample === true) {
     page.examples = [sample(page.examples)];

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "scripts": {
     "precommit": "npm run lint && npm run test:quiet",
     "prepush": "npm run test:quiet",
-    "postinstall": "node ./bin/tldr --update",
     "start": "node ./bin/tldr",
     "example": "node ./bin/tldr tar",
     "test": "mocha test --require=env-test",


### PR DESCRIPTION
- This was a source of errors for a long time. Now, we update the cache
on a page fetch miss.

Fixes #119 and #9 