### PR TITLE
Add --markdown output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To see tldr pages:
 - `tldr --list-all` show all available pages
 - `tldr --random` show a page at random
 - `tldr --random-example` show a single random example
+- `tldr --markdown` show the original markdown format page
 
 The client caches a copy of all pages locally, in `~/.tldr`.
 There are more commands to control the local cache:

--- a/bin/autocompletion.zsh
+++ b/bin/autocompletion.zsh
@@ -12,6 +12,7 @@ _arguments \
   '(- *)'{-1,--single-column}'[list one command per line (used with -l or -a)]' \
   '(- *)'{-r,--random}'[show a random command]' \
   '(- *)'{-e,--random-example}'[show a random example]' \
+  '(- *)'{-m,--markdown}'[show the original markdown format page]' \
   '(-f --render)'{-f,--render}'[render a specific markdown file]:markdown file:_files -/' \
   '(-o --os)'{-o,--os}"[override operating system]:os:${oses}" \
   '--linux[override operating system with Linux]' \

--- a/bin/tldr
+++ b/bin/tldr
@@ -19,6 +19,7 @@ program
   .option('-r, --random', 'Show a random command')
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
+  .option('-m, --markdown', 'Output in markdown format')
   .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos]')
   .option('--linux', 'Override the operating system with Linux')
   .option('--osx', 'Override the operating system with OSX')

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -24,8 +24,8 @@ exports.listAll = (singleColumn) => {
   });
 };
 
-exports.get = (commands) => {
-  printBestPage(commands.join('-'));
+exports.get = (commands, options) => {
+  printBestPage(commands.join('-'), options);
 };
 
 exports.random = () => {
@@ -97,6 +97,8 @@ function printPages(pages, singleColumn) {
 }
 
 function printBestPage(command, options) {
+  // TODO: replace with default parameter if Node v4 support dropped.
+  options = options || {};
   /* eslint-disable */ // To allow not checking for err
   // Trying to get the page from cache first
   cache.getPage(command, (err, content) => {
@@ -132,6 +134,9 @@ function printBestPage(command, options) {
 }
 
 function renderContent(content, options) {
+  if (options.markdown) {
+    return console.log(content);
+  }
   let page = parser.parse(content);
   if (options && options.randomExample === true) {
     page.examples = [sample(page.examples)];


### PR DESCRIPTION
## Description

Sometimes, we need the raw markdown output, such as another library consume the `tldr`'s output. For example, the [tldr plugin for Zazu](https://github.com/twang2218/zazu-tldr) need to have parsable output for processing.

So be able to have a raw markdown output would be handy.

I add `--markdown` or `-m` for short, for the raw markdown output option.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary

Signed-off-by: Tao Wang <twang2218@gmail.com>
