### PR TITLE
Use 'npm run test:all' in .travis.yml to also check lint error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "6"
   - "stable"
 script:
-  - npm test && npm run test:functional
+  - npm run test:all
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
## Description
As mentioned in https://github.com/tldr-pages/tldr-node-client/issues/128 , the `.travis.yml` didn't check `lint` error, and cause the error code bypass the local `precommit` hooks into the repo if local `eslint` or other dependencies are outdated or have problem.

I replaced `npm test && npm run test:functional` with `npm run test:all` to test `lint` as well.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [ ] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary

Signed-off-by: Tao Wang <twang2218@gmail.com>
