### PR TITLE
README: fix custom path for zsh autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ It's easiest for
 users, so let's start with that.
 
 ```
-mkdir -p $ZSH_CUSTOM/tldr
-ln -s bin/autocompletion.zsh $ZSH_CUSTOM/tldr/_tldr
+mkdir -p $ZSH_CUSTOM/plugins/tldr
+ln -s bin/autocompletion.zsh $ZSH_CUSTOM/plugins/tldr/_tldr
 ```
 
 Then add tldr to your oh-my-zsh plugins,


### PR DESCRIPTION
## Description
Path was missing the `custom` part, resulting in the plugin not being loaded.

## Checklist

- [x] Extended the README / documentation, if necessary
- [ ] N/A ~Code compiles correctly~
- [ ] N/A ~Created tests, if possible~
- [ ] N/A ~All tests passing (`npm run test:all`)~
