### PR TITLE
Remove sudo from installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ fpath = (my/completions $fpath)
 
 You probably have a permission problem, which you can solve [Here](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
-You can also use `sudo npm install -g tldr` to install, but [this pull request](https://github.com/tldr-pages/tldr-node-client/pull/142) will show you why you shoudn't.
-
 #### Colors under Cygwin
 
 Colors can't be shown under Mintty or PuTTY, because the dependency `colors.js` has a bug.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ fpath = (my/completions $fpath)
 
 ## FAQ
 
+#### `npm install -g tldr` throws an error
+
+You probably have a permission problem, which you can solve [Here](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
+
+You can also use `sudo npm install -g tldr` to install, but [this pull request](https://github.com/tldr-pages/tldr-node-client/pull/142) will show you why you shoudn't.
+
 #### Colors under Cygwin
 
 Colors can't be shown under Mintty or PuTTY, because the dependency `colors.js` has a bug.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A `Node.js` based command-line client for [tldr](https://github.com/tldr-pages/t
 ## Installing
 
 ```bash
-sudo npm install -g tldr
+npm install -g tldr
 ```
 ## Usage
 


### PR DESCRIPTION

## Description
removed the sudo from the readme installation area.

using sudo to install npm packages is not a best practice, see:

* https://docs.npmjs.com/getting-started/fixing-npm-permissions
* https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md
