### PR TITLE
Fix: Printing the error message properly

### DIFF
--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -58,7 +58,7 @@ exports.render = (file) => {
   // Reading the file
   fs.readFile(file, 'utf8', (err, content) => {
     if (err) {
-      console.error(err.stack);
+      console.error(err);
       exit(1);
     }
     // Getting the shortindex first to populate the shortindex var
@@ -78,7 +78,7 @@ exports.updateCache = () => {
   console.log('Updating...');
   cache.update((err) => {
     if (err) {
-      console.error(err.stack);
+      console.error(err);
       exit(1);
     }
     console.log('Done');
@@ -108,13 +108,13 @@ function printBestPage(command, options) {
       console.log('Page not found. Updating cache ..');
       cache.update((err) => {
         if (err) {
-          console.error(err.stack);
+          console.error(err);
           exit(1);
         }
         // And then, try to check in cache again
         cache.getPage(command, (err, content2) => {
           if (err) {
-            console.error(err.stack);
+            console.error(err);
             exit(1);
           }
           if (!content2) {
@@ -148,7 +148,7 @@ function renderContent(content, options) {
 function checkStale() {
   cache.lastUpdated((err, stats) => {
     if (err) {
-      console.error(err.stack);
+      console.error(err);
       exit(1);
     }
     if (stats.mtime < Date.now() - ms('30d')) {


### PR DESCRIPTION
- Printing the entire error instead of error.stack because `err.stack` becomes undefined.
