### PR TITLE
[Fixed]: Param wasn't being passed for --render option

### DIFF
--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -63,7 +63,7 @@ exports.render = (file) => {
     }
     // Getting the shortindex first to populate the shortindex var
     index.getShortIndex(() => {
-      renderContent(content);
+      renderContent(content, {});
     });
   });
 };


### PR DESCRIPTION
## Description

The options param wasn't being passed for the --render option. Passed an empty object.