### PR TITLE
Improve page not found message.

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -7,8 +7,7 @@ Please run tldr --update`;
   },
 
   notFound() {
-    return `Page not found
-Try updating with "tldr --update", or submit a pull request to:
-https://github.com/` + config.get().pagesRepository;
+    return `Page not found.
+Feel free to send a pull request to: https://github.com/` + config.get().pagesRepository;
   }
 };


### PR DESCRIPTION
## Description

Removing the redundant mention to tldr --update because
now the tool automatically runs a tldr --update when a page
does not exist
