### PR TITLE
Fixed documentation about pointing to a custom repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,11 @@ The default platform value can be overwritten with command-line option:
 tldr du --os=osx
 ```
 
-As a contributor, you can also point to your own fork or branch:
+As a contributor, you can also point to your own fork containing the `tldr.zip` file. The file is just a zipped version of the entire tldr repo:
 
 ```js
 {
-  "repository" : "myfork/tldr",
-  // or
-  "repository" : "myfork/tldr#mybranch",
+  "repository" : "http://myrepo/assets/tldr.zip",
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
-  "pagesRepository": "tldr-pages/tldr",
-  "url": "http://tldr-pages.github.io/assets/tldr.zip",
+  "repository": "http://tldr-pages.github.io/assets/tldr.zip",
   "themes": {
     "simple": {
       "commandName": "bold, underline",

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -41,7 +41,7 @@ exports.update = (done) => {
         return done(err);
       }
       // Copying from tmp to cache folder
-      fs.copy(tempFolder, CACHE_FOLDER, {clobber: true}, (err) => {
+      fs.copy(tempFolder, CACHE_FOLDER, (err) => {
         if (err) {
           return done(err);
         }

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -5,46 +5,26 @@ const os = require('os');
 const fs = require('fs-extra');
 const config  = require('./config');
 
-function source() {
-  let repository = config.get().repository;
-  if (repository) {
-    let parts  = repository.split('#');
-    let github = parts[0].match(/^(.*)\/(.*)$/);
-    return {
-      user: github[1],
-      repo: github[2],
-      branch: parts[1] || 'master'
-    };
-  }
-  return null;
-}
-
 // Downloads the zip file from github and extracts it to /tmp/tldr
 exports.download = (done) => {
   let request = require('request');
   let unzip   = require('unzip2');
-  let src = source();
-  let url = config.get().url;
+  let url = config.get().repository;
   let target = path.join(os.tmpdir(), 'tldr');
-  let inside = target;
-  if (src) {
-    url = 'https://github.com/' + src.user + '/' + src.repo + '/archive/' + src.branch + '.zip';
-    inside = path.join(target, src.repo + '-' + src.branch);
-  }
 
   // Empty the tmp dir
   fs.emptyDir(target, (err) => {
     if (err) {
-      return done(err, inside);
+      return done(err, null);
     }
 
     // Creating the extractor
     let extractor = unzip.Extract({path: target});
     extractor.on('error', () => {
-      done(new Error('Cannot update from ' + url), inside);
+      done(new Error('Cannot update from ' + url), null);
     });
     extractor.on('close', () => {
-      done(null, inside);
+      done(null, target);
     });
 
     // Setting the proxy if set by config

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "test:all": "npm run lint && npm test && npm run test:functional"
   },
   "dependencies": {
-    "chalk": "~1.1.1",
+    "chalk": "~2.3.0",
     "commander": "~2.9.0",
-    "fs-extra": "^0.30.0",
+    "fs-extra": "^4.0.2",
     "lodash.defaults": "~4.2.0",
     "lodash.get": "~4.4.2",
     "lodash.identity": "~3.0.0",


### PR DESCRIPTION
## Description

Fixes #159 

The code just needed the url for the zip file. But it redundantly
used 2 settings. The repository and a url attribute.

We only need the url. The repository was just used to get the name
of the underlying folder which was unecessary anyways. Therefore,
named the repository to point to the actual url. Code also got cleaned up
in this process.

Also updated few dependencies

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
~- [ ] Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
