### PR TITLE
Fixed the repo url msg in cache update

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "pagesRepository": "https://github.com/tldr-pages/tldr",
   "repository": "http://tldr-pages.github.io/assets/tldr.zip",
   "themes": {
     "simple": {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -8,6 +8,6 @@ Please run tldr --update`;
 
   notFound() {
     return `Page not found.
-Feel free to send a pull request to: https://github.com/` + config.get().pagesRepository;
+Feel free to send a pull request to: ` + config.get().pagesRepository;
   }
 };

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -9,13 +9,13 @@ describe('Config', () => {
   const DEFAULT =
 `
 {
-  "repository": "tldr-pages/tldr"
+  "repository": "http://tldr-pages.github.io/assets/tldr.zip"
 }`;
 
   const CUSTOM =
 `
 {
-  "repository": "myfork/tldr"
+  "repository": "http://myrepo/assets/tldr.zip"
 }`;
 
   const CUSTOM_INVALID =
@@ -45,13 +45,13 @@ describe('Config', () => {
   it('should load the default config', () => {
     fs.readFileSync.onCall(0).returns(DEFAULT);
     fs.readFileSync.onCall(1).throws('Not found');
-    config.get().repository.should.eql('tldr-pages/tldr');
+    config.get().repository.should.eql('http://tldr-pages.github.io/assets/tldr.zip');
   });
 
   it('should override the defaults with content from .tldrrc', () => {
     fs.readFileSync.onCall(0).returns(DEFAULT);
     fs.readFileSync.onCall(1).returns(CUSTOM);
-    config.get().repository.should.eql('myfork/tldr');
+    config.get().repository.should.eql('http://myrepo/assets/tldr.zip');
   });
 
   it('should validate the custom config format', () => {


### PR DESCRIPTION
## Description
The pagesRepository url was being used to show the message when a page
was not found in the repo. Therefore restored it.

Also fixed some test urls for config

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
~- [ ] Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
~- [ ] Extended the README / documentation, if necessary~
