### PR TITLE
Fix: Not raising an error for shortIndex.json not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,11 @@ function clearPagesIndex() {
       clearRuntimeIndex();
     })
     .catch((err) => {
-      console.error(err);
+      // If the file is not present, then it is already unlinked and our job is done.
+      // So raise an error only if it is some other scenario.
+      if (err.code !== 'ENOENT') {
+        console.error(err);
+      }
     });
 }
 


### PR DESCRIPTION
## Description
When the cache tries to update for the first time, the shortIndex.json
file is not present. Therefore, it prints an error when it tries to
delete it.

But if the file is already not present, that means the job of unlinking
is already complete. So not raising an error in that condition

Fixes #180 

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
~- [ ] Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
~- [ ] Extended the README / documentation, if necessary~
