### PR TITLE
Promisify methods without extra wrappers

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,47 +9,27 @@ const index = require('./index');
 
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
 
-exports.lastUpdated = (done) => {
-  fs.stat(CACHE_FOLDER, done);
-};
+exports.lastUpdated = () => fs.stat(CACHE_FOLDER);
 
-exports.getPage = (page, done) => {
+exports.getPage = (page) => {
   let preferredPlatform = platform.getPreferredPlatformFolder();
-  index.findPlatform(page, preferredPlatform)
+  return index.findPlatform(page, preferredPlatform)
     .then((folder) => {
-      if (folder) {
-        let filePath = path.join(CACHE_FOLDER, 'pages', folder, page + '.md');
-        fs.readFile(filePath, 'utf8', done);
-      } else {
-        done(null, null);
+      if (!folder) {
+        return;
       }
+      let filePath = path.join(CACHE_FOLDER, 'pages', folder, page + '.md');
+      return fs.readFile(filePath, 'utf8');
     })
-    .catch((err) => {
-      console.error(err);
-      done(null, null);
-    });
+    .catch((err) => console.error(err));
 };
 
-exports.clear = (done) => {
-  fs.remove(CACHE_FOLDER, done);
-};
+exports.clear = () => fs.remove(CACHE_FOLDER);
 
-exports.update = (done) => {
+exports.update = () => {
   // Downloading fresh copy
-  fs.ensureDir(CACHE_FOLDER)
-    .then(() => {
-      return remote.download();
-    })
-    .then((tempFolder) => {
-      return fs.copy(tempFolder, CACHE_FOLDER);
-    })
-    .then(() => {
-      return index.rebuildPagesIndex();
-    })
-    .then(() => {
-      return done();
-    })
-    .catch((err) => {
-      return done(err);
-    });
+  return fs.ensureDir(CACHE_FOLDER)
+    .then(() => remote.download())
+    .then((tempFolder) => fs.copy(tempFolder, CACHE_FOLDER))
+    .then(() => index.rebuildPagesIndex());
 };

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -23,7 +23,9 @@ exports.getPage = (page) => {
       let filePath = path.join(CACHE_FOLDER, 'pages', folder, page + '.md');
       return fs.readFile(filePath, 'utf8');
     })
-    .catch((err) => console.error(err));
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 exports.clear = () => {
@@ -33,7 +35,13 @@ exports.clear = () => {
 exports.update = () => {
   // Downloading fresh copy
   return fs.ensureDir(CACHE_FOLDER)
-    .then(() => remote.download())
-    .then((tempFolder) => fs.copy(tempFolder, CACHE_FOLDER))
-    .then(() => index.rebuildPagesIndex());
+    .then(() => {
+      return remote.download();
+    })
+    .then((tempFolder) => {
+      return fs.copy(tempFolder, CACHE_FOLDER);
+    })
+    .then(() => {
+      return index.rebuildPagesIndex();
+    });
 };

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,7 +9,9 @@ const index = require('./index');
 
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
 
-exports.lastUpdated = () => fs.stat(CACHE_FOLDER);
+exports.lastUpdated = () => {
+  return fs.stat(CACHE_FOLDER);
+};
 
 exports.getPage = (page) => {
   let preferredPlatform = platform.getPreferredPlatformFolder();
@@ -24,7 +26,9 @@ exports.getPage = (page) => {
     .catch((err) => console.error(err));
 };
 
-exports.clear = () => fs.remove(CACHE_FOLDER);
+exports.clear = () => {
+  return fs.remove(CACHE_FOLDER);
+};
 
 exports.update = () => {
   // Downloading fresh copy

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,27 +11,22 @@ const pagesPath = path.join(config.get().cache, 'cache/pages');
 const shortIndexFile = path.join(pagesPath, 'shortIndex.json');
 
 function findPlatform(page, preferredPlatform) {
-  return new Promise((resolve, reject) => {
-    // Load the index
-    getShortIndex()
-      .then((idx) => {
-        // First, check whether page is in the index
-        if (! (page in idx)) {
-          return resolve(null);
-        }
-        // Get the platforms
-        let platforms = idx[page];
-        if (platforms.indexOf(preferredPlatform) >= 0) {
-          return resolve(preferredPlatform);
-        } else if (platforms.indexOf('common') >= 0) {
-          return resolve('common');
-        }
-        return resolve(null);
-      })
-      .catch((err) => {
-        return reject(err);
-      });
-  });
+  // Load the index
+  return getShortIndex()
+    .then((idx) => {
+      // First, check whether page is in the index
+      if (! (page in idx)) {
+        return null;
+      }
+      // Get the platforms
+      let platforms = idx[page];
+      if (platforms.indexOf(preferredPlatform) >= 0) {
+        return preferredPlatform;
+      } else if (platforms.indexOf('common') >= 0) {
+        return 'common';
+      }
+      return null;
+    });
 }
 
 // hasPage is always called after the index is created,
@@ -46,42 +41,27 @@ function hasPage(page) {
 
 // Return all commands available in the local cache.
 function commands() {
-  return new Promise((resolve, reject) => {
-    getShortIndex()
-      .then((idx) => {
-        return resolve(Object.keys(idx).sort());
-      })
-      .catch((err) => {
-        return reject(err);
-      });
-  });
+  return getShortIndex().then((idx) => Object.keys(idx).sort());
 }
 
 // Return all commands for a given platform.
 // P.S. - The platform 'common' is always included.
 function commandsFor(platform) {
-  return new Promise((resolve, reject) => {
-    getShortIndex()
-      .then((idx) => {
-        let commands = Object.keys(idx)
-          .filter((cmd) => {
-            return idx[cmd].indexOf(platform) !== -1 || idx[cmd].indexOf('common') !== -1;
-          })
-          .sort();
-        resolve(commands);
-      })
-      .catch((err) => {
-        return reject(err);
-      });
-  });
+  return getShortIndex()
+    .then((idx) => {
+      let commands = Object.keys(idx)
+        .filter((cmd) => {
+          return idx[cmd].indexOf(platform) !== -1 || idx[cmd].indexOf('common') !== -1;
+        })
+        .sort();
+      return commands;
+    });
 }
 
 // Delete the index file.
 function clearPagesIndex() {
   return fs.unlink(shortIndexFile)
-    .then(() => {
-      clearRuntimeIndex();
-    })
+    .then(() => clearRuntimeIndex())
     .catch((err) => {
       // If the file is not present, then it is already unlinked and our job is done.
       // So raise an error only if it is some other scenario.
@@ -97,69 +77,32 @@ function clearRuntimeIndex() {
 }
 
 function rebuildPagesIndex() {
-  return new Promise((resolve, reject) => {
-    clearPagesIndex()
-      .then(() => {
-        return getShortIndex();
-      })
-      .then(() => {
-        resolve();
-      })
-      .catch((err) => {
-        reject(err);
-      });
-  });
+  return clearPagesIndex().then(() => getShortIndex());
 }
 
 // If the variable is not set, read the file and set it.
 // Else, just return the variable.
 function getShortIndex() {
-  return new Promise((resolve, reject) => {
-    if (shortIndex) {
-      resolve(shortIndex);
-    } else {
-      readShortPagesIndex()
-        .then((idx) => {
-          resolve(idx);
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }
-  });
+  if (shortIndex) {
+    return Promise.resolve(shortIndex);
+  }
+  return readShortPagesIndex();
 }
 
 // Read the index file, and load it into memory.
 // If the file does not exist, create the data structure, write the file,
 // and load it into memory.
 function readShortPagesIndex() {
-  return new Promise((resolve, reject) => {
-    fs.readFile(shortIndexFile, 'utf8')
-      .then((idx) => {
-        // File is present, so just parse
-        // and set the shortIndex variable,
-        // then resolve the value.
-        idx = JSON.parse(idx);
-        shortIndex = idx;
-        return resolve(idx);
-      })
-      .catch(() => {
-        // File is not present; we need to create the index.
-        let idx = buildShortPagesIndex();
-        if (Object.keys(idx).length > 0) {
-          fs.writeFile(shortIndexFile, JSON.stringify(idx))
-            .then(() => {
-              shortIndex = idx;
-              return resolve(idx);
-            })
-            .catch((err) => {
-              reject(err);
-            });
-        } else {
-          return resolve(idx);
-        }
-      });
-  });
+  return fs.readJson(shortIndexFile)
+    .catch(() => {
+      // File is not present; we need to create the index.
+      let idx = buildShortPagesIndex();
+      if (Object.keys(idx).length <= 0) {
+        return idx;
+      }
+      return fs.writeJson(shortIndexFile, idx).then(() => idx);
+    })
+    .then((idx) => (shortIndex = idx));
 }
 
 function buildShortPagesIndex() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,9 @@ function hasPage(page) {
 
 // Return all commands available in the local cache.
 function commands() {
-  return getShortIndex().then((idx) => Object.keys(idx).sort());
+  return getShortIndex().then((idx) => {
+    return Object.keys(idx).sort();
+  });
 }
 
 // Return all commands for a given platform.
@@ -61,7 +63,9 @@ function commandsFor(platform) {
 // Delete the index file.
 function clearPagesIndex() {
   return fs.unlink(shortIndexFile)
-    .then(() => clearRuntimeIndex())
+    .then(() => {
+      return clearRuntimeIndex();
+    })
     .catch((err) => {
       // If the file is not present, then it is already unlinked and our job is done.
       // So raise an error only if it is some other scenario.
@@ -77,7 +81,9 @@ function clearRuntimeIndex() {
 }
 
 function rebuildPagesIndex() {
-  return clearPagesIndex().then(() => getShortIndex());
+  return clearPagesIndex().then(() => {
+    return getShortIndex();
+  });
 }
 
 // If the variable is not set, read the file and set it.
@@ -100,9 +106,14 @@ function readShortPagesIndex() {
       if (Object.keys(idx).length <= 0) {
         return idx;
       }
-      return fs.writeJson(shortIndexFile, idx).then(() => idx);
+      return fs.writeJson(shortIndexFile, idx).then(() => {
+        return idx;
+      });
     })
-    .then((idx) => (shortIndex = idx));
+    .then((idx) => {
+      shortIndex = idx;
+      return shortIndex;
+    });
 }
 
 function buildShortPagesIndex() {

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -32,11 +32,15 @@ exports.download = () => {
       req.pipe(extractor);
 
       return new Promise((resolve, reject) => {
-        req.on('error', (err) => reject(err));
+        req.on('error', (err) => {
+          reject(err);
+        });
         extractor.on('error', () => {
           reject(new Error('Cannot update from ' + url));
         });
-        extractor.on('close', () => resolve(target));
+        extractor.on('close', () => {
+          resolve(target);
+        });
       });
     });
 };

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -8,43 +8,35 @@ const config  = require('./config');
 // Downloads the zip file from github and extracts it to /tmp/tldr
 exports.download = () => {
   let request = require('request');
-  let unzip   = require('unzip2');
+  let unzip = require('unzip2');
   let url = config.get().repository;
   let target = path.join(os.tmpdir(), 'tldr');
 
   // Empty the tmp dir
-  return new Promise((resolve, reject) => {
-    fs.emptyDir(target)
-      .then(() => {
-        // Creating the extractor
-        let extractor = unzip.Extract({path: target});
+  return fs.emptyDir(target)
+    .then(() => {
+      // Creating the extractor
+      let extractor = unzip.Extract({ path: target });
+
+      // Setting the proxy if set by config
+      if (config.get().proxy) {
+        request = request.defaults({ proxy: config.proxy });
+      }
+
+      // Creating the request and passing the extractor
+      let req = request.get({
+        url: url,
+        headers: { 'User-Agent' : 'tldr-node-client' }
+      });
+
+      req.pipe(extractor);
+
+      return new Promise((resolve, reject) => {
+        req.on('error', (err) => reject(err));
         extractor.on('error', () => {
           reject(new Error('Cannot update from ' + url));
         });
-        extractor.on('close', () => {
-          resolve(target);
-        });
-
-        // Setting the proxy if set by config
-        if (config.get().proxy) {
-          request = request.defaults({
-            'proxy':config.proxy
-          });
-        }
-
-        // Creating the request and passing the extractor
-        let req = request.get({
-          url: url,
-          headers: {'User-Agent' : 'tldr-node-client'}
-        });
-
-        req.on('error', (err) => {
-          reject(err);
-        });
-        req.pipe(extractor);
-      })
-      .catch((err) => {
-        reject(err);
+        extractor.on('close', () => resolve(target));
       });
-  });
+    });
 };

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -115,7 +115,7 @@ function printBestPage(command, options={}) {
       if (content) {
         checkStale();
         renderContent(content, options);
-        return exit(0);
+        return exit();
       }
       // If not found, try to update
       console.log('Page not found. Updating cache ..');
@@ -158,7 +158,7 @@ function renderContent(content, options={}) {
 
 function checkStale() {
   cache.lastUpdated()
-    .then(stats => {
+    .then((stats) => {
       if (stats.mtime < Date.now() - ms('30d')) {
         console.warn('Cache is out of date, you should run "tldr --update"');
       }

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -15,16 +15,12 @@ const exit = process.exit;
 exports.list = (singleColumn) => {
   let os = platform.getPreferredPlatformFolder();
   index.commandsFor(os)
-    .then((commands) => {
-      printPages(commands, singleColumn);
-    });
+    .then((commands) => printPages(commands, singleColumn));
 };
 
 exports.listAll = (singleColumn) => {
   index.commands()
-    .then((commands) => {
-      printPages(commands, singleColumn);
-    });
+    .then((commands) => printPages(commands, singleColumn));
 };
 
 exports.get = (commands, options) => {
@@ -43,9 +39,7 @@ exports.random = () => {
       console.log('PAGE', page);
       printBestPage(page);
     })
-    .catch((err) => {
-      console.error(err);
-    });
+    .catch((err) => console.error(err));
 };
 
 exports.randomExample = () => {
@@ -60,70 +54,46 @@ exports.randomExample = () => {
       console.log('PAGE', page);
       printBestPage(page, {randomExample: true});
     })
-    .catch((err) => {
-      console.error(err);
-    });
+    .catch((err) => console.error(err));
 };
 
 exports.render = (file) => {
-  fs.readFile(file, 'utf8', (err, content) => {
-    if (err) {
+  fs.readFile(file, 'utf8')
+    .then((content) => {
+      // Getting the shortindex first to populate the shortindex var
+      return index.getShortIndex().then(() => renderContent(content));
+    })
+    .catch((err) => {
       console.error(err);
       exit(1);
-    }
-    // Getting the shortindex first to populate the shortindex var
-    index.getShortIndex()
-      .then(() => {
-        renderContent(content);
-      })
-      .catch((err) => {
-        console.error(err);
-        exit(1);
-      });
-  });
+    });
 };
 
 exports.clearCache = () => {
-  cache.clear(() => {
-    console.log('Done');
-  });
+  cache.clear().then(() => console.log('Done'));
 };
 
 exports.updateCache = () => {
   console.log('Updating...');
-  return new Promise(function(resolve, reject) {
-    cache.update((err) => {
-      if (err) {
-        console.error(err);
-        exit(1);
-        reject(err);
-      } else {
-        console.log('Done');
-        resolve();
-      }
+  return cache.update()
+    .then(() => console.log('Done'))
+    .catch((err) => {
+      console.error(err);
+      exit(1);
     });
-  });
 };
 
 exports.updateIndex = () => {
   console.log('Creating index...');
   search.createIndex()
-    .then(() => {
-      console.log('Done');
-    })
-    .catch((err) => {
-      console.error(err);
-    });
+    .then(() => console.log('Done'))
+    .catch((err) => console.error(err));
 };
 
 exports.search = (keywords) => {
   search.getResults(keywords.join(' '))
-    .then((results) => {
-      search.printResults(results);
-    })
-    .catch((err) => {
-      console.error(err);
-    });
+    .then((results) => search.printResults(results))
+    .catch((err) => console.error(err));
 };
 
 function printPages(pages, singleColumn) {
@@ -138,46 +108,40 @@ function printPages(pages, singleColumn) {
 }
 
 function printBestPage(command, options={}) {
-  /* eslint-disable */ // To allow not checking for err
   // Trying to get the page from cache first
-  cache.getPage(command, (err, content) => {
-  /* eslint-enable */
-    if (!content) {
+  cache.getPage(command)
+    .then((content) => {
+      // If found in first try, render it
+      if (content) {
+        checkStale();
+        renderContent(content, options);
+        return exit(0);
+      }
       // If not found, try to update
       console.log('Page not found. Updating cache ..');
-      cache.update((err) => {
-        if (err) {
-          console.error(err);
-          exit(1);
-        }
-        console.log('Creating index...');
-        search.createIndex()
-          .then(() => {
-            console.log('Done');
-            // And then, try to check in cache again
-            cache.getPage(command, (err, content2) => {
-              if (err) {
-                console.error(err);
-                exit(1);
-              }
-              if (!content2) {
-                console.error(messages.notFound());
-                exit(1);
-              } else {
-                checkStale();
-                renderContent(content2, options);
-              }
-            });
-          })
-          .catch((err) => {
-            console.error(err);
-          });
-      });
-    } else { // If found in first try, render it
+      return cache.update();
+    })
+    .then(() => {
+      console.log('Creating index...');
+      return search.createIndex();
+    })
+    .then(() => {
+      console.log('Done');
+      // And then, try to check in cache again
+      return cache.getPage(command);
+    })
+    .then((content) => {
+      if (!content) {
+        console.error(messages.notFound());
+        return exit(1);
+      }
       checkStale();
       renderContent(content, options);
-    }
-  });
+    })
+    .catch((err) => {
+      console.error(err);
+      exit(1);
+    });
 }
 
 function renderContent(content, options={}) {
@@ -193,13 +157,14 @@ function renderContent(content, options={}) {
 }
 
 function checkStale() {
-  cache.lastUpdated((err, stats) => {
-    if (err) {
+  cache.lastUpdated()
+    .then(stats => {
+      if (stats.mtime < Date.now() - ms('30d')) {
+        console.warn('Cache is out of date, you should run "tldr --update"');
+      }
+    })
+    .catch(err => {
       console.error(err);
       exit(1);
-    }
-    if (stats.mtime < Date.now() - ms('30d')) {
-      console.warn('Cache is out of date, you should run "tldr --update"');
-    }
-  });
+    });
 }

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -15,12 +15,16 @@ const exit = process.exit;
 exports.list = (singleColumn) => {
   let os = platform.getPreferredPlatformFolder();
   index.commandsFor(os)
-    .then((commands) => printPages(commands, singleColumn));
+    .then((commands) => {
+      printPages(commands, singleColumn);
+    });
 };
 
 exports.listAll = (singleColumn) => {
   index.commands()
-    .then((commands) => printPages(commands, singleColumn));
+    .then((commands) => {
+      printPages(commands, singleColumn);
+    });
 };
 
 exports.get = (commands, options) => {
@@ -39,7 +43,9 @@ exports.random = () => {
       console.log('PAGE', page);
       printBestPage(page);
     })
-    .catch((err) => console.error(err));
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 exports.randomExample = () => {
@@ -54,14 +60,18 @@ exports.randomExample = () => {
       console.log('PAGE', page);
       printBestPage(page, {randomExample: true});
     })
-    .catch((err) => console.error(err));
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 exports.render = (file) => {
   fs.readFile(file, 'utf8')
     .then((content) => {
       // Getting the shortindex first to populate the shortindex var
-      return index.getShortIndex().then(() => renderContent(content));
+      return index.getShortIndex().then(() => {
+        renderContent(content);
+      });
     })
     .catch((err) => {
       console.error(err);
@@ -70,13 +80,17 @@ exports.render = (file) => {
 };
 
 exports.clearCache = () => {
-  cache.clear().then(() => console.log('Done'));
+  cache.clear().then(() => {
+    console.log('Done');
+  });
 };
 
 exports.updateCache = () => {
   console.log('Updating...');
   return cache.update()
-    .then(() => console.log('Done'))
+    .then(() => {
+      console.log('Done');
+    })
     .catch((err) => {
       console.error(err);
       exit(1);
@@ -86,14 +100,22 @@ exports.updateCache = () => {
 exports.updateIndex = () => {
   console.log('Creating index...');
   search.createIndex()
-    .then(() => console.log('Done'))
-    .catch((err) => console.error(err));
+    .then(() => {
+      console.log('Done');
+    })
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 exports.search = (keywords) => {
   search.getResults(keywords.join(' '))
-    .then((results) => search.printResults(results))
-    .catch((err) => console.error(err));
+    .then((results) => {
+      search.printResults(results);
+    })
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 function printPages(pages, singleColumn) {
@@ -163,7 +185,7 @@ function checkStale() {
         console.warn('Cache is out of date, you should run "tldr --update"');
       }
     })
-    .catch(err => {
+    .catch((err) => {
       console.error(err);
       exit(1);
     });

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -14,7 +14,9 @@ describe('Cache', () => {
     // eslint-disable-next-line no-magic-numbers
     this.timeout(30000);
     return cache.update()
-      .then(() => cache.lastUpdated())
+      .then(() => {
+        return cache.lastUpdated();
+      })
       .then((stats) => {
         should.exist(stats);
         stats.mtime.should.be.aboveOrEqual(0);
@@ -82,7 +84,9 @@ describe('Cache', () => {
 
     it('should return empty contents for non-existing page', () => {
       return cache.getPage('qwerty')
-        .then((content) => should.not.exist(content));
+        .then((content) => {
+          return should.not.exist(content);
+        });
     });
   });
 });

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -9,18 +9,16 @@ const platform = require('../lib/platform');
 
 
 describe('Cache', () => {
-  it('should return a positive number on lastUpdate', function(done) {
-    /* eslint-disable */ // To allow setting timeout of 30 secs
+  it('should return a positive number on lastUpdate', function () {
+    // To allow setting timeout of 30 secs
+    // eslint-disable-next-line no-magic-numbers
     this.timeout(30000);
-    cache.update((err) => {
-    /* eslint-enable */
-      cache.lastUpdated((err, stats) => {
-        should.not.exist(err);
+    return cache.update()
+      .then(() => cache.lastUpdated())
+      .then((stats) => {
         should.exist(stats);
         stats.mtime.should.be.aboveOrEqual(0);
-        done();
       });
-    });
   });
 
   describe('getPage()', () => {
@@ -41,62 +39,50 @@ describe('Cache', () => {
       index.getShortIndex.restore();
     });
 
-    it('should return page contents for ls', (done) => {
-      sinon.stub(fs, 'readFile').callsFake((path, encoding, cb) => {
-        return cb(null, '# ls\n> ls page');
-      });
+    it('should return page contents for ls', () => {
+      sinon.stub(fs, 'readFile').resolves('# ls\n> ls page');
       sinon.stub(platform, 'getPreferredPlatformFolder').returns('osx');
       sinon.stub(index, 'findPlatform').resolves('osx');
-      cache.getPage('ls', (err, content) => {
-        should.not.exist(err);
-        should.exist(content);
-        content.should.startWith('# ls');
-        fs.readFile.restore();
-        platform.getPreferredPlatformFolder.restore();
-        index.findPlatform.restore();
-        done();
-      });
+      return cache.getPage('ls')
+        .then((content) => {
+          should.exist(content);
+          content.should.startWith('# ls');
+          fs.readFile.restore();
+          platform.getPreferredPlatformFolder.restore();
+          index.findPlatform.restore();
+        });
     });
 
-    it('should return empty contents for svcs on OSX', (done) =>{
-      sinon.stub(fs, 'readFile').callsFake((path, encoding, cb) => {
-        return cb(null, '# svcs\n> svcs');
-      });
+    it('should return empty contents for svcs on OSX', () =>{
+      sinon.stub(fs, 'readFile').resolves('# svcs\n> svcs');
       sinon.stub(platform, 'getPreferredPlatformFolder').returns('osx');
       sinon.stub(index, 'findPlatform').resolves(null);
-      cache.getPage('svc', (err, content) => {
-        should.not.exist(err);
-        should.not.exist(content);
-        fs.readFile.restore();
-        platform.getPreferredPlatformFolder.restore();
-        index.findPlatform.restore();
-        done();
-      });
+      return cache.getPage('svc')
+        .then((content) => {
+          should.not.exist(content);
+          fs.readFile.restore();
+          platform.getPreferredPlatformFolder.restore();
+          index.findPlatform.restore();
+        });
     });
 
-    it('should return page contents for svcs on SunOS', (done) => {
-      sinon.stub(fs, 'readFile').callsFake((path, encoding, cb) => {
-        return cb(null, '# svcs\n> svcs');
-      });
+    it('should return page contents for svcs on SunOS', () => {
+      sinon.stub(fs, 'readFile').resolves('# svcs\n> svcs');
       sinon.stub(platform, 'getPreferredPlatformFolder').returns('sunos');
       sinon.stub(index, 'findPlatform').resolves('svcs');
-      cache.getPage('svcs', (err, content) => {
-        should.not.exist(err);
-        should.exist(content);
-        content.should.startWith('# svcs');
-        fs.readFile.restore();
-        platform.getPreferredPlatformFolder.restore();
-        index.findPlatform.restore();
-        done();
-      });
+      return cache.getPage('svcs')
+        .then((content) => {
+          should.exist(content);
+          content.should.startWith('# svcs');
+          fs.readFile.restore();
+          platform.getPreferredPlatformFolder.restore();
+          index.findPlatform.restore();
+        });
     });
 
-    it('should return empty contents for non-existing page', (done) => {
-      cache.getPage('qwerty', (err, content) => {
-        should.not.exist(err);
-        should.not.exist(content);
-        done();
-      });
+    it('should return empty contents for non-existing page', () => {
+      return cache.getPage('qwerty')
+        .then((content) => should.not.exist(content));
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,112 +26,78 @@ describe('Index', () => {
         'sunos/du.md',
         'sunos/svcs.md'
       ]);
-    sinon.stub(fs, 'readFile')
-      .rejects('dummy error');
-    sinon.stub(fs, 'writeFile')
-      .resolves('');
+    sinon.stub(fs, 'readJson').rejects('dummy error');
+    sinon.stub(fs, 'writeJson').resolves('');
   });
 
   afterEach(() => {
     utils.walkSync.restore();
-    fs.readFile.restore();
-    fs.writeFile.restore();
+    fs.readJson.restore();
+    fs.writeJson.restore();
   });
 
   describe('findPlatform()', () => {
-    it('should find Linux platform for dd command', (done) => {
-      index.findPlatform('dd', 'linux')
-        .then((folder) => {
-          folder.should.equal('linux');
-          done();
-        });
+    it('should find Linux platform for dd command', () => {
+      return index.findPlatform('dd', 'linux')
+        .then((folder) => folder.should.equal('linux'));
     });
 
-    it('should find platform common for cp command', (done) => {
-      index.findPlatform('cp', 'linux')
-        .then((folder) => {
-          folder.should.equal('common');
-          done();
-        });
+    it('should find platform common for cp command', () => {
+      return index.findPlatform('cp', 'linux')
+        .then((folder) => folder.should.equal('common'));
     });
 
-    it('should not find platform for svcs command on Linux', (done) => {
-      index.findPlatform('svcs', 'linux')
-        .then((folder) => {
-          should.not.exist(folder);
-          done();
-        });
+    it('should not find platform for svcs command on Linux', () => {
+      return index.findPlatform('svcs', 'linux')
+        .then((folder) => should.not.exist(folder));
     });
 
-    it('should not find platform for non-existing command', (done) => {
-      index.findPlatform('qwerty', 'linux')
-        .then((folder) => {
-          should.not.exist(folder);
-          done();
-        });
+    it('should not find platform for non-existing command', () => {
+      return index.findPlatform('qwerty', 'linux')
+        .then((folder) => should.not.exist(folder));
     });
   });
 
-  it('should return correct list of all pages', (done) => {
-    index.commands()
+  it('should return correct list of all pages', () => {
+    return index.commands()
       .then((commands) => {
         commands.should.deepEqual([
           'cp', 'dd', 'du', 'git', 'ln', 'ls', 'svcs', 'top'
         ]);
-        done();
-      })
-      .catch((err) => {
-        console.error(err);
-        done();
       });
   });
 
   describe('commandsFor()', () => {
-    it('should return correct list of pages for Linux', (done) => {
-      index.commandsFor('linux')
+    it('should return correct list of pages for Linux', () => {
+      return index.commandsFor('linux')
         .then((commands) => {
           commands.should.deepEqual([
             'cp', 'dd', 'du', 'git', 'ln', 'ls', 'top'
           ]);
-          done();
-        })
-        .catch((err) => {
-          console.error(err);
-          done();
         });
     });
 
-    it('should return correct list of pages for OSX', (done) => {
-      index.commandsFor('osx')
+    it('should return correct list of pages for OSX', () => {
+      return index.commandsFor('osx')
         .then((commands) => {
           commands.should.deepEqual([
             'cp', 'dd', 'du', 'git', 'ln', 'ls', 'top'
           ]);
-          done();
-        })
-        .catch((err) => {
-          console.error(err);
-          done();
         });
     });
 
-    it('should return correct list of pages for SunOS', (done) => {
-      index.commandsFor('sunos')
+    it('should return correct list of pages for SunOS', () => {
+      return index.commandsFor('sunos')
         .then((commands) => {
           commands.should.deepEqual([
             'cp', 'dd', 'du', 'git', 'ln', 'ls', 'svcs'
           ]);
-          done();
-        })
-        .catch((err) => {
-          console.error(err);
-          done();
         });
     });
   });
 
-  it('should return correct short index on getShortIndex()', (done) => {
-    index.getShortIndex()
+  it('should return correct short index on getShortIndex()', () => {
+    return index.getShortIndex()
       .then((idx) => {
         idx.should.deepEqual({
           cp: ['common'],
@@ -143,11 +109,6 @@ describe('Index', () => {
           top: ['linux', 'osx'],
           svcs: ['sunos']
         });
-        done();
-      })
-      .catch((err) => {
-        console.error(err);
-        done();
       });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -39,22 +39,30 @@ describe('Index', () => {
   describe('findPlatform()', () => {
     it('should find Linux platform for dd command', () => {
       return index.findPlatform('dd', 'linux')
-        .then((folder) => folder.should.equal('linux'));
+        .then((folder) => {
+          return folder.should.equal('linux');
+        });
     });
 
     it('should find platform common for cp command', () => {
       return index.findPlatform('cp', 'linux')
-        .then((folder) => folder.should.equal('common'));
+        .then((folder) => {
+          return folder.should.equal('common');
+        });
     });
 
     it('should not find platform for svcs command on Linux', () => {
       return index.findPlatform('svcs', 'linux')
-        .then((folder) => should.not.exist(folder));
+        .then((folder) => {
+          return should.not.exist(folder);
+        });
     });
 
     it('should not find platform for non-existing command', () => {
       return index.findPlatform('qwerty', 'linux')
-        .then((folder) => should.not.exist(folder));
+        .then((folder) => {
+          return should.not.exist(folder);
+        });
     });
   });
 


### PR DESCRIPTION
## Description
Continuing promisification effort; unwrapping promise chains as described here: https://github.com/tldr-pages/tldr-node-client/issues/160#issuecomment-371617564

Refactored `#readShortPagesIndex` to use `#readJson`/`#writeJson` (from `fs-extra`); makes code even simpler 🏄 

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
