### PR TITLE
Bugfix: Don't set shortIndex if index is empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,10 @@ function getShortIndex() {
 // and load it into memory.
 function readShortPagesIndex() {
   return fs.readJson(shortIndexFile)
+    .then((idx) => {
+      shortIndex = idx;
+      return shortIndex;
+    })
     .catch(() => {
       // File is not present; we need to create the index.
       let idx = buildShortPagesIndex();
@@ -107,12 +111,9 @@ function readShortPagesIndex() {
         return idx;
       }
       return fs.writeJson(shortIndexFile, idx).then(() => {
-        return idx;
+        shortIndex = idx;
+        return shortIndex;
       });
-    })
-    .then((idx) => {
-      shortIndex = idx;
-      return shortIndex;
     });
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,26 +6,63 @@ const utils = require('../lib/utils');
 const sinon = require('sinon');
 const should = require('should');
 
+const pages = [
+  'index.json',
+  'common/cp.md',
+  'common/git.md',
+  'common/ln.md',
+  'common/ls.md',
+  'linux/dd.md',
+  'linux/du.md',
+  'linux/top.md',
+  'osx/dd.md',
+  'osx/du.md',
+  'osx/top.md',
+  'sunos/dd.md',
+  'sunos/du.md',
+  'sunos/svcs.md'
+];
+
+describe('Index building', () => {
+  beforeEach(() => {
+    index.rebuildPagesIndex();
+    sinon.stub(fs, 'readJson').rejects('dummy error');
+    sinon.stub(fs, 'writeJson').resolves('');
+  });
+
+  describe('failure', () => {
+    before(() => {
+      sinon.stub(utils, 'walkSync').throws('dummy error');
+    });
+
+    it('shortIndex should not be created', () => {
+      return index.hasPage('cp').should.be.false() &&
+        index.hasPage('dummy').should.be.false();
+    });
+  });
+
+  describe('success', () => {
+    before(() => {
+      sinon.stub(utils, 'walkSync').returns(pages);
+    });
+
+    it('correct shortIndex should be created', () => {
+      return index.hasPage('cp').should.be.true() &&
+        index.hasPage('dummy').should.be.false();
+    });
+  });
+
+  afterEach(() => {
+    utils.walkSync.restore();
+    fs.readJson.restore();
+    fs.writeJson.restore();
+  });
+});
+
 describe('Index', () => {
   beforeEach(() => {
     index.clearRuntimeIndex();
-    sinon.stub(utils, 'walkSync')
-      .returns([
-        'index.json',
-        'common/cp.md',
-        'common/git.md',
-        'common/ln.md',
-        'common/ls.md',
-        'linux/dd.md',
-        'linux/du.md',
-        'linux/top.md',
-        'osx/dd.md',
-        'osx/du.md',
-        'osx/top.md',
-        'sunos/dd.md',
-        'sunos/du.md',
-        'sunos/svcs.md'
-      ]);
+    sinon.stub(utils, 'walkSync').returns(pages);
     sinon.stub(fs, 'readJson').rejects('dummy error');
     sinon.stub(fs, 'writeJson').resolves('');
   });


### PR DESCRIPTION
## Description
Commit 84eb2bf introduced my _reviewed_ promisification code which unfortunately behaves incorrectly. While doing refactor I've accidentally changed behavior of `#readShortPagesIndex` to **always** assign `shortIndex` variable to calculated value which is in fact wrong in cases where `#buildShortPagesIndex` returns empty index. This leads to situation where very first query on initial run after installation (cache has not been downloaded yet) will fail because first check will assign `shortIndex` to empty object and after cache is downloaded client will ignore it and simply return `shortIndex`'s empty value due to:
```js
function getShortIndex() {
  if (shortIndex) {
    return Promise.resolve(shortIndex);
  }
  return readShortPagesIndex();
}
```
It is time to clean my mess, so that's why I'm offering this hotfix :ambulance: 

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
