### PR TITLE
Make index tests wait for async setup to get finished

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -25,9 +25,9 @@ const pages = [
 
 describe('Index building', () => {
   beforeEach(() => {
-    index.rebuildPagesIndex();
     sinon.stub(fs, 'readJson').rejects('dummy error');
     sinon.stub(fs, 'writeJson').resolves('');
+    return index.rebuildPagesIndex();
   });
 
   describe('failure', () => {


### PR DESCRIPTION
## Description
@agnivade encountered strange build failure (explanation here: https://github.com/tldr-pages/tldr-node-client/pull/212#issuecomment-385181161) that was in fact caused by lousy test (probably written by me :man_facepalming:). Root cause was race condition between setup/preparation step and actual test execution and this PR eliminates it by making tests to wait for async setup to get finished.
It went under radar because in most cases `#rebuildPagesIndex` operation finished almost instantly.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
