### PR TITLE
Remove cache refreshing when page not found (fix #225)

### DIFF
--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -145,8 +145,8 @@ function printBestPage(command, options={}) {
         return exit();
       }
       // If not found, try to update
-      spinner.start('Page not found. Updating cache');
-      return cache.update();
+      console.log('Page not found');
+      return exit();
     })
     .then(() => {
       spinner.succeed();

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -144,7 +144,6 @@ function printBestPage(command, options={}) {
         renderContent(content, options);
         return exit();
       }
-      // If not found, try to update
       console.log('Page not found');
       return exit();
     })


### PR DESCRIPTION
## Description
Instead of refreshing every time when a page is not found, this change will just return an error indication that the page is not found.

Rationale:

- The current cache refreshing behavior happens every time when a page is not found, even when the user just refreshes the cache in the previous command. Since each refreshing takes noticeable delay, it becomes a bit time overhead when the users tries multiple commands.
- It might be also confusing to a new user when he runs the same command again and the tldr is doing the same thing, instead of providing a positive result this time, or giving a faster reply
- Installing bash auto-completion might help. But the auto-completion script is not available in every `tldr` supported platform. It's not even installed by default on Linux.


## Checklist

Please review this checklist before submitting a pull request.

- [X] Code compiles correctly
    - I also tested it and it gives results correctly.
- [X] Created tests, if possible
    - Doesn't seem to be needed.
- [ ] All tests passing (`npm run test:all`) 
    - For some reason, running `npm run test:all` failed on my machine even for the current official master branch, saying `TypeError: Cannot read property 'commandName' of undefined` for the `Render`. But apparently the current CI is passing. So I will see if it passes CI as well.
- [X] Extended the README / documentation, if necessary
    - Doesn't seem to be needed.