### PR TITLE
add stub for config.js in render.spec.js (fix #229)

### DIFF
--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -2,12 +2,27 @@
 
 const render = require('../lib/render');
 const config = require('../lib/config');
+const sinon = require('sinon');
 
 describe('Render', () => {
 
   beforeEach(() => {
-    config.reset();
-    config.get().theme = 'base16';
+    sinon.stub(config, 'get').returns({
+      'themes': {
+        'base16': {
+          'commandName': 'bold',
+          'mainDescription': '',
+          'exampleDescription': 'green',
+          'exampleCode': 'red',
+          'exampleToken': 'cyan'
+        }
+      },
+      'theme': 'base16'
+    });
+  });
+
+  afterEach(() => {
+    config.get.restore();
   });
 
   it('surrounds the output with blank lines', () => {


### PR DESCRIPTION
## Description
This PR fixes #229. It's a cleaned-up re-submission of PR #232.

To test it, put the following content in your `$HOME/.tldrrc` before applying the change:

```
{
  "themes": {
    "ocean": {
      "commandName": "bold, cyan",
      "mainDescription": "",
      "exampleDescription": "green",
      "exampleCode": "cyan",
      "exampleToken": "dim"
    }
  },
  "theme": "ocean"
}

```
The `npm test` should fail as described in #229. Then apply this change, it should pass.

## Checklist

Please review this checklist before submitting a pull request.

- [X] Code compiles correctly
- [X] Created tests, if possible
- [X] All tests passing (`npm run test:all`)
- [X] Extended the README / documentation, if necessary
