### PR TITLE
[Update]: Point to the https path for assets

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "pagesRepository": "https://github.com/tldr-pages/tldr",
-  "repository": "http://tldr-pages.github.io/assets/tldr.zip",
+  "repository": "https://tldr-pages.github.io/assets/tldr.zip",
   "themes": {
     "simple": {
       "commandName": "bold, underline",


### PR DESCRIPTION
## Description

 This helps in case when the tldr-pages.github.io is CNAMED to a
domain (like tldr.sh) which is hijacked.
