### PR TITLE
fix: improve the error message when an invalid theme is passed.

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -8,6 +8,10 @@ const config = require('./config');
 exports.toANSI = (page) => {
   // Creating the theme object
   let themeOptions = config.get().themes[config.get().theme];
+  if (!themeOptions) {
+    console.error(`invalid theme: ${config.get().theme}`);
+    return;
+  }
   let theme = new Theme(themeOptions);
 
   function highlight(code) {

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -181,7 +181,9 @@ function renderContent(content, options={}) {
     page.examples = [sample(page.examples)];
   }
   let output = render.toANSI(page);
-  console.log(output);
+  if (output) {
+    console.log(output);
+  }
 }
 
 function checkStale() {

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -3,6 +3,7 @@
 const render = require('../lib/render');
 const config = require('../lib/config');
 const sinon = require('sinon');
+const should = require('should');
 
 describe('Render', () => {
 
@@ -22,7 +23,7 @@ describe('Render', () => {
   });
 
   afterEach(() => {
-    config.get.restore();
+    sinon.restore();
   });
 
   it('surrounds the output with blank lines', () => {
@@ -84,5 +85,29 @@ describe('Render', () => {
       ]
     });
     text.should.containEql('See also: lsb_release, sudo');
+  });
+
+  it('should return an error for invalid theme', () => {
+    config.get.restore();
+    sinon.stub(config, 'get').returns({
+      'themes': {
+        'base16': {
+          'commandName': 'bold',
+          'mainDescription': '',
+          'exampleDescription': 'green',
+          'exampleCode': 'red',
+          'exampleToken': 'cyan'
+        }
+      },
+      'theme': 'bad'
+    });
+
+    let spy = sinon.spy(console, 'error');
+    let text = render.toANSI({
+      name: 'tar',
+      description: 'archive utility',
+    });
+    should.not.exist(text);
+    spy.getCall(0).args[0].should.equal('invalid theme: bad');
   });
 });


### PR DESCRIPTION
## Description

Previous implementation will just throw a bad stack trace. Now
we validate the theme value being passed and show a proper message.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
~- [ ] Extended the README / documentation, if necessary~
