### PR TITLE
Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "test": "test"
   },
   "scripts": {
-    "precommit": "npm run lint && npm run test:quiet",
-    "prepush": "npm run test:quiet",
     "start": "node ./bin/tldr",
     "example": "node ./bin/tldr tar",
     "test": "mocha test --require=env-test",
@@ -67,5 +65,11 @@
     "mocha": "^4.0.1",
     "should": "^13.2.3",
     "sinon": "^7.3.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint && npm run test:quiet",
+      "pre-push": "npm run test:quiet"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm run test:quiet",
+      "pre-commit": "npm run lint",
       "pre-push": "npm run test:quiet"
     }
   }


### PR DESCRIPTION
## Description
fix: remove test from pre-commit
    
    Having to run the entire test suite for every commit is painful.
    The general workflow is to commit often. And since pre-push already
    has the test command, hence removing it from pre-commit.

update: husky hooks
    
    According to this warning message -
    Warning: Setting pre-push script in package.json > scripts will be deprecated
    Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
    
    Hence moving it to package.json file
