### PR TITLE
Remove fixed TODO

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -79,7 +79,6 @@ if (program.os) {
 }
 
 if (program.theme) {
-  // TODO: Validate theme
   config.get().theme = program.theme;
 }
 


### PR DESCRIPTION
## Description
We show a better error msg for invalid theme
in 5c98eb5412fa101dac15f86231fee65a1a72d6a0.
