### PR TITLE
Refactor cache folder

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -2,7 +2,7 @@
 
 const program = require('commander');
 const pkg = require('../package');
-const tldr = require('../lib/tldr');
+const Tldr = require('../lib/tldr');
 const config = require('../lib/config');
 const platform = require('../lib/platform');
 
@@ -71,16 +71,18 @@ if (program.sunos) {
   program.os = 'sunos';
 }
 
-
+let cfg = config.get();
 if (program.os) {
   if (platform.isSupported(program.os)) {
-    config.get().platform = program.os;
+    cfg.platform = program.os;
   }
 }
 
 if (program.theme) {
-  config.get().theme = program.theme;
+  cfg.theme = program.theme;
 }
+
+const tldr = new Tldr(cfg);
 
 if (program.list) {
   tldr.list(program.singleColumn);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,7 +10,6 @@ const index = require('./index');
 const utils = require('./utils');
 
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
-const TEMP_FOLDER = path.join(os.tmpdir(), 'tldr');
 
 exports.lastUpdated = () => {
   return fs.stat(CACHE_FOLDER);
@@ -37,7 +36,7 @@ exports.clear = () => {
 
 exports.update = () => {
   // Temporary folder path: /tmp/tldr/{randomName}
-  let tempFolder = path.join(TEMP_FOLDER, utils.uniqueId());
+  const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
 
   // Downloading fresh copy
   return Promise.all([

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,64 +3,72 @@
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
-const config = require('./config');
 const remote = require('./remote');
 const platform = require('./platform');
 const index = require('./index');
 const utils = require('./utils');
 
-const CACHE_FOLDER = path.join(config.get().cache, 'cache');
+class Cache {
+  constructor(config) {
+    // TODO: replace this with a private field when it reaches enough maturity
+    // https://github.com/tc39/proposal-class-fields#private-fields
+    this.config = config;
+    this.cacheFolder = path.join(config.cache, 'cache');
+  }
 
-exports.lastUpdated = () => {
-  return fs.stat(CACHE_FOLDER);
-};
+  lastUpdated() {
+    return fs.stat(this.cacheFolder);
+  }
 
-exports.getPage = (page) => {
-  let preferredPlatform = platform.getPreferredPlatformFolder();
-  return index.findPlatform(page, preferredPlatform)
-    .then((folder) => {
-      if (!folder) {
-        return;
-      }
-      let filePath = path.join(CACHE_FOLDER, 'pages', folder, page + '.md');
-      return fs.readFile(filePath, 'utf8');
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-};
+  getPage(page) {
+    let preferredPlatform = platform.getPreferredPlatformFolder(this.config);
+    return index.findPlatform(page, preferredPlatform)
+      .then((folder) => {
+        if (!folder) {
+          return;
+        }
+        let filePath = path.join(this.cacheFolder, 'pages', folder, page + '.md');
+        return fs.readFile(filePath, 'utf8');
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
 
-exports.clear = () => {
-  return fs.remove(CACHE_FOLDER);
-};
+  clear() {
+    return fs.remove(this.cacheFolder);
+  }
 
-exports.update = () => {
-  // Temporary folder path: /tmp/tldr/{randomName}
-  const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
+  update() {
+    // Temporary folder path: /tmp/tldr/{randomName}
+    const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
 
-  // Downloading fresh copy
-  return Promise.all([
-    // Create new temporary folder
-    fs.ensureDir(tempFolder),
-    fs.ensureDir(CACHE_FOLDER)
-  ])
-    .then(() => {
-      // Download and extract cache data to temporary folder
-      return remote.download(tempFolder);
-    })
-    .then(() => {
-      // Copy data to cache folder
-      return fs.copy(tempFolder, CACHE_FOLDER);
-    })
-    .then(() => {
-      return Promise.all([
-        // Remove temporary folder
-        fs.remove(tempFolder),
-        index.rebuildPagesIndex()
-      ]);
-    })
-    // eslint-disable-next-line no-unused-vars
-    .then(([_, shortIndex]) => {
-      return shortIndex;
-    });
-};
+    // Downloading fresh copy
+    return Promise.all([
+      // Create new temporary folder
+      fs.ensureDir(tempFolder),
+      fs.ensureDir(this.cacheFolder)
+    ])
+      .then(() => {
+        // Download and extract cache data to temporary folder
+        return remote.download(tempFolder);
+      })
+      .then(() => {
+        // Copy data to cache folder
+        return fs.copy(tempFolder, this.cacheFolder);
+      })
+      .then(() => {
+        return Promise.all([
+          // Remove temporary folder
+          fs.remove(tempFolder),
+          index.rebuildPagesIndex()
+        ]);
+      })
+      // eslint-disable-next-line no-unused-vars
+      .then(([_, shortIndex]) => {
+        return shortIndex;
+      });
+  }
+}
+
+module.exports = Cache;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -12,8 +12,6 @@ const utils = require('./utils');
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
 const TEMP_FOLDER = path.join(os.tmpdir(), 'tldr');
 
-exports.CACHE_FOLDER = CACHE_FOLDER;
-
 exports.lastUpdated = () => {
   return fs.stat(CACHE_FOLDER);
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,20 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const osHomedir = require('os-homedir');
 
-let config = null;
-
-exports.reset = () => {
-  config = null;
-};
-
 exports.get = () => {
-  if (!config) {
-    config = load();
-  }
-  return config;
-};
-
-function load() {
   const DEFAULT = path.join(__dirname, '..', 'config.json');
   const CUSTOM = path.join(osHomedir(), '.tldrrc');
 
@@ -51,7 +38,7 @@ function load() {
     throw new Error('Error in .tldrrc configuration:\n' + errors.join('\n'));
   }
   return merged;
-}
+};
 
 function validatePlatform(os) {
   let platform = require('./platform');

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const os = require('os');
-const config = require('./config');
 
 const folders = {
   'osx': 'osx',
@@ -18,34 +17,22 @@ function isSupported(platform) {
 
 // If the platform given in config is present, return that.
 // Else, return the system platform
-function getPreferredPlatform() {
-  let platform = config.get().platform;
+function getPreferredPlatform(config) {
+  let platform = config.platform;
   if (isSupported(platform)) {
     return platform;
   }
   return os.platform();
 }
 
-function specific(command, platform) {
-  return platform + '/' + command + '.md';
-}
-
-function resolve(command) {
-  return [
-    specific(command, getPreferredPlatformFolder()),
-    specific(command, 'common')
-  ];
-}
-
 // Get the folder name for a platform
-function getPreferredPlatformFolder() {
-  let platform = getPreferredPlatform();
+function getPreferredPlatformFolder(config) {
+  let platform = getPreferredPlatform(config);
   return folders[platform];
 }
 
 module.exports = {
   isSupported,
   getPreferredPlatform,
-  getPreferredPlatformFolder,
-  resolve
+  getPreferredPlatformFolder
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,15 +1,14 @@
 'use strict';
 
 const Theme = require('./theme');
-const config = require('./config');
 
 // The page structure is passed to this function, and then the theme is applied
 // to different parts of the page and rendered to the console
-exports.toANSI = (page) => {
+exports.toANSI = (page, config) => {
   // Creating the theme object
-  let themeOptions = config.get().themes[config.get().theme];
+  let themeOptions = config.themes[config.theme];
   if (!themeOptions) {
-    console.error(`invalid theme: ${config.get().theme}`);
+    console.error(`invalid theme: ${config.theme}`);
     return;
   }
   let theme = new Theme(themeOptions);

--- a/lib/search.js
+++ b/lib/search.js
@@ -185,7 +185,7 @@ let processQuery = (rawquery) => {
   });
 };
 
-exports.printResults = (results) => {
+exports.printResults = (results, config) => {
   // Prints the passed results to the console.
   // If the command is not available for the current platform,
   // it lists the available platforms instead.
@@ -193,7 +193,7 @@ exports.printResults = (results) => {
   //              $ tree (Available on: linux, osx)
   index.getShortIndex().then((shortIndex) => {
     let outputs = new Set();
-    let preferredPlatform = platform.getPreferredPlatform();
+    let preferredPlatform = platform.getPreferredPlatform(config);
     results.forEach((elem) => {
       let cmdname = utils.parsePagename(elem.file);
       let output = '    $ ' + cmdname;

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -4,7 +4,7 @@ const sample = require('lodash/sample');
 const fs = require('fs-extra');
 const ms = require('ms');
 const ora = require('ora');
-const cache = require('./cache');
+const Cache = require('./cache');
 const search = require('./search');
 const platform = require('./platform');
 const messages = require('./messages');
@@ -13,188 +13,200 @@ const render = require('./render');
 const index = require('./index');
 const exit = process.exit;
 
-exports.list = (singleColumn) => {
-  let os = platform.getPreferredPlatformFolder();
-  index.commandsFor(os)
-    .then((commands) => {
-      printPages(commands, singleColumn);
-    });
-};
+class Tldr {
+  constructor(config) {
+    // TODO: replace this with a private field when it reaches enough maturity
+    // https://github.com/tc39/proposal-class-fields#private-fields
+    this.config = config;
+    this.cache = new Cache(this.config);
+  }
 
-exports.listAll = (singleColumn) => {
-  index.commands()
-    .then((commands) => {
-      printPages(commands, singleColumn);
-    });
-};
-
-exports.get = (commands, options) => {
-  printBestPage(commands.join('-'), options);
-};
-
-exports.random = (options) => {
-  let os = platform.getPreferredPlatformFolder();
-  index.commandsFor(os)
-    .then((pages) => {
-      if (pages.length === 0) {
-        console.error(messages.emptyCache());
-        exit(1);
-      }
-      let page = sample(pages);
-      console.log('PAGE', page);
-      printBestPage(page, options);
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-};
-
-exports.randomExample = () => {
-  let os = platform.getPreferredPlatformFolder();
-  index.commandsFor(os)
-    .then((pages) => {
-      if (pages.length === 0) {
-        console.error(messages.emptyCache());
-        exit(1);
-      }
-      let page = sample(pages);
-      console.log('PAGE', page);
-      printBestPage(page, {randomExample: true});
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-};
-
-exports.render = (file) => {
-  fs.readFile(file, 'utf8')
-    .then((content) => {
-      // Getting the shortindex first to populate the shortindex var
-      return index.getShortIndex().then(() => {
-        renderContent(content);
+  list(singleColumn) {
+    let os = platform.getPreferredPlatformFolder(this.config);
+    index.commandsFor(os)
+      .then((commands) => {
+        this.printPages(commands, singleColumn);
       });
-    })
-    .catch((err) => {
-      console.error(err);
-      exit(1);
-    });
-};
-
-exports.clearCache = () => {
-  cache.clear().then(() => {
-    console.log('Done');
-  });
-};
-
-exports.updateCache = () => {
-  const spinner = ora();
-  spinner.start('Updating...');
-  return cache.update()
-    .then(() => {
-      spinner.succeed();
-    })
-    .catch((err) => {
-      console.error(err);
-      exit(1);
-    });
-};
-
-exports.updateIndex = () => {
-  const spinner = ora();
-  spinner.start('Creating index...');
-  search.createIndex()
-    .then(() => {
-      spinner.succeed();
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-};
-
-exports.search = (keywords) => {
-  search.getResults(keywords.join(' '))
-    .then((results) => {
-      search.printResults(results);
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-};
-
-function printPages(pages, singleColumn) {
-  if (pages.length === 0) {
-    console.error(messages.emptyCache());
-    exit(1);
   }
-  checkStale();
-  let endOfLine = require('os').EOL;
-  let delimiter = singleColumn ? endOfLine : ', ';
-  console.log('\n' + pages.join(delimiter));
+
+  listAll(singleColumn) {
+    index.commands()
+      .then((commands) => {
+        this.printPages(commands, singleColumn);
+      });
+  }
+
+  get(commands, options) {
+    this.printBestPage(commands.join('-'), options);
+  }
+
+  random(options) {
+    let os = platform.getPreferredPlatformFolder(this.config);
+    index.commandsFor(os)
+      .then((pages) => {
+        if (pages.length === 0) {
+          console.error(messages.emptyCache());
+          exit(1);
+        }
+        let page = sample(pages);
+        console.log('PAGE', page);
+        this.printBestPage(page, options);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  randomExample() {
+    let os = platform.getPreferredPlatformFolder(this.config);
+    index.commandsFor(os)
+      .then((pages) => {
+        if (pages.length === 0) {
+          console.error(messages.emptyCache());
+          exit(1);
+        }
+        let page = sample(pages);
+        console.log('PAGE', page);
+        this.printBestPage(page, {randomExample: true});
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  render(file) {
+    fs.readFile(file, 'utf8')
+      .then((content) => {
+        // Getting the shortindex first to populate the shortindex var
+        return index.getShortIndex().then(() => {
+          this.renderContent(content);
+        });
+      })
+      .catch((err) => {
+        console.error(err);
+        exit(1);
+      });
+  }
+
+  clearCache() {
+    this.cache.clear().then(() => {
+      console.log('Done');
+    });
+  }
+
+  updateCache() {
+    const spinner = ora();
+    spinner.start('Updating...');
+    return this.cache.update()
+      .then(() => {
+        spinner.succeed();
+      })
+      .catch((err) => {
+        console.error(err);
+        exit(1);
+      });
+  }
+
+  updateIndex() {
+    const spinner = ora();
+    spinner.start('Creating index...');
+    search.createIndex()
+      .then(() => {
+        spinner.succeed();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  search(keywords) {
+    search.getResults(keywords.join(' '))
+      .then((results) => {
+        // TODO: make search into a class also.
+        search.printResults(results, this.config);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  printPages(pages, singleColumn) {
+    if (pages.length === 0) {
+      console.error(messages.emptyCache());
+      exit(1);
+    }
+    this.checkStale();
+    let endOfLine = require('os').EOL;
+    let delimiter = singleColumn ? endOfLine : ', ';
+    console.log('\n' + pages.join(delimiter));
+  }
+
+  printBestPage(command, options={}) {
+    const spinner = ora();
+
+    // Trying to get the page from cache first
+    this.cache.getPage(command)
+      .then((content) => {
+        // If found in first try, render it
+        if (content) {
+          this.checkStale();
+          this.renderContent(content, options);
+          return exit();
+        }
+        // If not found, try to update
+        spinner.start('Page not found. Updating cache...');
+        return this.cache.update();
+      })
+      .then(() => {
+        spinner.succeed();
+        spinner.start('Creating index...');
+        return search.createIndex();
+      })
+      .then(() => {
+        spinner.succeed();
+        // And then, try to check in cache again
+        return this.cache.getPage(command);
+      })
+      .then((content) => {
+        if (!content) {
+          console.error(messages.notFound());
+          return exit(1);
+        }
+        this.checkStale();
+        this.renderContent(content, options);
+      })
+      .catch((err) => {
+        console.error(err);
+        exit(1);
+      });
+  }
+
+  checkStale() {
+    this.cache.lastUpdated()
+      .then((stats) => {
+        if (stats.mtime < Date.now() - ms('30d')) {
+          console.warn('Cache is out of date. You should run "tldr --update"');
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        exit(1);
+      });
+  }
+
+  renderContent(content, options={}) {
+    if (options.markdown) {
+      return console.log(content);
+    }
+    let page = parser.parse(content);
+    if (options && options.randomExample === true) {
+      page.examples = [sample(page.examples)];
+    }
+    let output = render.toANSI(page, this.config);
+    if (output) {
+      console.log(output);
+    }
+  }
 }
 
-function printBestPage(command, options={}) {
-  const spinner = ora();
-
-  // Trying to get the page from cache first
-  cache.getPage(command)
-    .then((content) => {
-      // If found in first try, render it
-      if (content) {
-        checkStale();
-        renderContent(content, options);
-        return exit();
-      }
-      // If not found, try to update
-      spinner.start('Page not found. Updating cache...');
-      return cache.update();
-    })
-    .then(() => {
-      spinner.succeed();
-      spinner.start('Creating index...');
-      return search.createIndex();
-    })
-    .then(() => {
-      spinner.succeed();
-      // And then, try to check in cache again
-      return cache.getPage(command);
-    })
-    .then((content) => {
-      if (!content) {
-        console.error(messages.notFound());
-        return exit(1);
-      }
-      checkStale();
-      renderContent(content, options);
-    })
-    .catch((err) => {
-      console.error(err);
-      exit(1);
-    });
-}
-
-function renderContent(content, options={}) {
-  if (options.markdown) {
-    return console.log(content);
-  }
-  let page = parser.parse(content);
-  if (options && options.randomExample === true) {
-    page.examples = [sample(page.examples)];
-  }
-  let output = render.toANSI(page);
-  if (output) {
-    console.log(output);
-  }
-}
-
-function checkStale() {
-  cache.lastUpdated()
-    .then((stats) => {
-      if (stats.mtime < Date.now() - ms('30d')) {
-        console.warn('Cache is out of date. You should run "tldr --update"');
-      }
-    })
-    .catch((err) => {
-      console.error(err);
-      exit(1);
-    });
-}
+module.exports = Tldr;

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const cache = require('../lib/cache');
+const config = require('../lib/config');
 const should = require('should');
 const sinon = require('sinon');
+const path = require('path');
 const fs = require('fs-extra');
 const index = require('../lib/index');
 const remote = require('../lib/remote');
@@ -35,11 +37,12 @@ describe('Cache', () => {
 
     it('should use randomly created temp folder', () => {
       const count = 16;
+      const cacheFolder = path.join(config.get().cache, 'cache');
       return Promise.all(Array.from({ length: count }).map(() => {
         return cache.update();
       })).then(() => {
         let calls = fs.ensureDir.getCalls().filter((call) => {
-          return !call.calledWith(cache.CACHE_FOLDER);
+          return !call.calledWith(cacheFolder);
         });
         calls.should.have.length(count);
         let tempFolders = calls.map((call) => {
@@ -50,9 +53,10 @@ describe('Cache', () => {
     });
 
     it('should remove temp folder after cache gets updated', () => {
+      const cacheFolder = path.join(config.get().cache, 'cache');
       return cache.update().then(() => {
         let createFolder = fs.ensureDir.getCalls().find((call) => {
-          return !call.calledWith(cache.CACHE_FOLDER);
+          return !call.calledWith(cacheFolder);
         });
         let removeFolder = fs.remove.getCall(0);
         removeFolder.args[0].should.be.equal(createFolder.args[0]);

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -35,7 +35,6 @@ describe('Config', () => {
 
   beforeEach(() => {
     sinon.stub(fs, 'readFileSync');
-    config.reset();
   });
 
   afterEach(() => {

--- a/test/functional-test.sh
+++ b/test/functional-test.sh
@@ -8,6 +8,8 @@ function tldr-render-pages {
   tldr zip && \
   tldr du --os=linux && \
   tldr du --os=osx && \
+  tldr du --os=linux --markdown && \
+  tldr du --os=osx --markdown && \
   tldr --random && \
   tldr --random-example && \
   tldr --list && \

--- a/test/platform.spec.js
+++ b/test/platform.spec.js
@@ -10,34 +10,33 @@ describe('Platform', () => {
   describe('getPreferredPlatform', () => {
     beforeEach(() => {
       sinon.stub(os, 'platform');
-      sinon.stub(config, 'get');
+      this.config = config.get();
     });
 
     afterEach(() => {
       os.platform.restore();
-      config.get.restore();
     });
 
     it('should return the running platform with no configuration', () => {
       os.platform.onCall(0).returns('darwin');
-      config.get.onCall(0).returns({});
-      platform.getPreferredPlatform().should.eql('darwin');
+      this.config = {};
+      platform.getPreferredPlatform(this.config).should.eql('darwin');
     });
 
     it('should overwrite the running platform if configured', () => {
       os.platform.onCall(0).returns('darwin');
-      config.get.onCall(0).returns({
+      this.config = {
         platform: 'linux'
-      });
-      platform.getPreferredPlatform().should.eql('linux');
+      };
+      platform.getPreferredPlatform(this.config).should.eql('linux');
     });
 
     it('should return current system platform if configuration is wrong', () => {
       os.platform.onCall(0).returns('darwin');
-      config.get.onCall(0).returns({
+      this.config = {
         platform: 'there_is_no_such_platform'
-      });
-      platform.getPreferredPlatform().should.eql('darwin');
+      };
+      platform.getPreferredPlatform(this.config).should.eql('darwin');
     });
   });
 
@@ -48,24 +47,6 @@ describe('Platform', () => {
       platform.isSupported('sunos').should.eql(true);
       platform.isSupported('windows').should.eql(true);
       platform.isSupported('ios').should.eql(false);
-    });
-  });
-
-  describe('resolve', () => {
-    beforeEach(() => {
-      sinon.stub(os, 'platform');
-    });
-
-    afterEach(() => {
-      os.platform.restore();
-    });
-
-    it('should resolve tar command with specific OS and common folder', () => {
-      os.platform.onCall(0).returns('linux');
-      platform.resolve('tar').should.eql([
-        'linux/tar.md',
-        'common/tar.md'
-      ]);
     });
   });
 });

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const render = require('../lib/render');
-const config = require('../lib/config');
 const sinon = require('sinon');
 const should = require('should');
 
 describe('Render', () => {
 
   beforeEach(() => {
-    sinon.stub(config, 'get').returns({
+    this.config = {
       'themes': {
         'base16': {
           'commandName': 'bold',
@@ -19,7 +18,7 @@ describe('Render', () => {
         }
       },
       'theme': 'base16'
-    });
+    };
   });
 
   afterEach(() => {
@@ -31,7 +30,7 @@ describe('Render', () => {
       name: 'tar',
       description: 'archive utility',
       examples: []
-    });
+    }, this.config);
     text.should.startWith('\n');
     text.should.endWith('\n');
   });
@@ -41,7 +40,7 @@ describe('Render', () => {
       name: 'tar',
       description: 'archive utility',
       examples: []
-    });
+    }, this.config);
     text.should.containEql('tar');
     text.should.containEql('archive utility');
   });
@@ -51,7 +50,7 @@ describe('Render', () => {
       name: 'tar',
       description: 'archive utility\nwith support for compression',
       examples: []
-    });
+    }, this.config);
     text.should.containEql('archive utility');
     text.should.containEql('with support for compression');
   });
@@ -64,7 +63,7 @@ describe('Render', () => {
         description: 'create',
         code: 'hello {{token}} bye'
       }]
-    });
+    }, this.config);
     text.should.containEql('hello ');
     text.should.containEql('token');
     text.should.containEql(' bye');
@@ -83,13 +82,12 @@ describe('Render', () => {
         'lsb_release',
         'sudo'
       ]
-    });
+    }, this.config);
     text.should.containEql('See also: lsb_release, sudo');
   });
 
   it('should return an error for invalid theme', () => {
-    config.get.restore();
-    sinon.stub(config, 'get').returns({
+    const config = {
       'themes': {
         'base16': {
           'commandName': 'bold',
@@ -100,13 +98,13 @@ describe('Render', () => {
         }
       },
       'theme': 'bad'
-    });
+    };
 
     let spy = sinon.spy(console, 'error');
     let text = render.toANSI({
       name: 'tar',
       description: 'archive utility',
-    });
+    }, config);
     should.not.exist(text);
     spy.getCall(0).args[0].should.equal('invalid theme: bad');
   });


### PR DESCRIPTION
## Description
 Refactor: remove global variable TEMP_FOLDER
    
    It was only being used once. So derive it there itself.

Refactor: remove unnecessary cache export of CACHE_FOLDER
    
    This was needed only for test and could be derived in the test itself.
    
    First step towards removing those global variables.


## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
~- [ ] Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
~- [ ] Extended the README / documentation, if necessary~
