### PR TITLE
Removing `os-homedir` as it's deprecated

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@
 const defaults = require('lodash/defaults');
 const fs = require('fs');
 const path = require('path');
-const osHomedir = require('os-homedir');
+const osHomedir = require('os').homedir;
 
 exports.get = () => {
   const DEFAULT = path.join(__dirname, '..', 'config.json');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,11 +1687,6 @@
         }
       }
     },
-    "os-homedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-      "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q=="
-    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "natural": "^0.6.3",
     "node-unzip-2": "^0.2.8",
     "ora": "^3.4.0",
-    "os-homedir": "^2.0.0",
     "request": "^2.88.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

According to the [docs](https://nodejs.org/api/os.html#os_os_homedir)
`os.homedir` has been available since node v2.3.0. Therefore, `os-homedir` is likely unneeded for compat, especially as you only test for 10+

I'm unsure if you want a version bump included

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] ~Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
- [ ] ~Extended the README / documentation, if necessary~
