### PR TITLE
Update cache if older than 30 days

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const ms = require('ms');
 const os = require('os');
 const path = require('path');
 const remote = require('./remote');
@@ -18,6 +19,18 @@ class Cache {
 
   lastUpdated() {
     return fs.stat(this.cacheFolder);
+  }
+
+  isStale() {
+    this
+      .lastUpdated()
+      .then((stats) => {
+        return stats.mtime < Date.now() - ms('30d');
+      })
+      .catch((err) => {
+        console.error(err);
+        process.exit(1);
+      });
   }
 
   getPage(page) {

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -2,7 +2,6 @@
 
 const sample = require('lodash/sample');
 const fs = require('fs-extra');
-const ms = require('ms');
 const ora = require('ora');
 const Cache = require('./cache');
 const search = require('./search');
@@ -97,7 +96,8 @@ class Tldr {
   updateCache() {
     const spinner = ora();
     spinner.start('Updating...');
-    return this.cache.update()
+    return this.cache
+      .update()
       .then(() => {
         spinner.succeed();
       })
@@ -182,16 +182,9 @@ class Tldr {
   }
 
   checkStale() {
-    this.cache.lastUpdated()
-      .then((stats) => {
-        if (stats.mtime < Date.now() - ms('30d')) {
-          console.warn('Cache is out of date. You should run "tldr --update"');
-        }
-      })
-      .catch((err) => {
-        console.error(err);
-        exit(1);
-      });
+    if (this.cache.isStale()) {
+      this.updateCache();
+    }
   }
 
   renderContent(content, options={}) {


### PR DESCRIPTION
## Overview

This PR supersedes #198.

The previous behavior would still check if the cache were more than 30 days out of date, but all it would do was warn the user to run `tldr --update`.

The intention behind this fix is that because tldr CAN update itself, it should just try to update automatically when the cache is out of date instead of bothering the user.

## Description

- There is now a `cache.isStale()` method which returns a boolean indicating whether or not the cache is more than 30 days out of date
- `checkStale()` in `tldr.js` now calls `cache.isStale()`, and if that call returns true, it automatically runs `updateCache` instead of warning the user.

## Checklist

Please review this checklist before submitting a pull request.

- [X] Code compiles correctly
- [X] Created tests, if possible
- [X] All tests passing (`npm run test:all`)
- [X] Extended the README / documentation, if necessary
