### PR TITLE
Reduce dependency and number of calls for config.get

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,19 +1,17 @@
 'use strict';
 
 const fs = require('fs-extra');
-const os = require('os');
 const path = require('path');
 const remote = require('./remote');
 const platform = require('./platform');
 const index = require('./index');
-const utils = require('./utils');
 
 class Cache {
   constructor(config) {
     // TODO: replace this with a private field when it reaches enough maturity
     // https://github.com/tc39/proposal-class-fields#private-fields
     this.config = config;
-    this.cacheFolder = path.join(config.cache, 'cache');
+    this.cacheFolder = config.cacheFolder;
   }
 
   lastUpdated() {
@@ -23,7 +21,7 @@ class Cache {
   getPage(page) {
     let preferredPlatform = platform.getPreferredPlatformFolder(this.config);
     const preferredLanguage = process.env.LANG || 'en';
-    return index.findPage(page, preferredPlatform, preferredLanguage)
+    return index.findPage(this.config, page, preferredPlatform, preferredLanguage)
       .then((folder) => {
         if (!folder) {
           return;
@@ -42,7 +40,7 @@ class Cache {
 
   update() {
     // Temporary folder path: /tmp/tldr/{randomName}
-    const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
+    const tempFolder = this.config.tempFolder;
 
     // Downloading fresh copy
     return Promise.all([
@@ -52,7 +50,7 @@ class Cache {
     ])
       .then(() => {
         // Download and extract cache data to temporary folder
-        return remote.download(tempFolder);
+        return remote.download(this.config, tempFolder);
       })
       .then(() => {
         // Copy data to cache folder
@@ -62,7 +60,7 @@ class Cache {
         return Promise.all([
           // Remove temporary folder
           fs.remove(tempFolder),
-          index.rebuildPagesIndex()
+          index.rebuildPagesIndex(this.config)
         ]);
       })
       // eslint-disable-next-line no-unused-vars

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,17 +3,13 @@
 const defaults = require('lodash/defaults');
 const fs = require('fs');
 const path = require('path');
-const osHomedir = require('os').homedir;
+const utils = require('./utils');
+const os = require('os');
+const osHomedir = os.homedir;
 
 exports.get = () => {
-  const DEFAULT = path.join(__dirname, '..', 'config.json');
   const CUSTOM = path.join(osHomedir(), '.tldrrc');
-
-  let defaultConfig = JSON.parse(fs.readFileSync(DEFAULT));
-  defaultConfig.cache = path.join(osHomedir(), '.tldr');
-  /*eslint-disable no-process-env */
-  defaultConfig.proxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  /*eslint-enable no-process-env */
+  let defaultConfig = generateBaseConfig();
 
   let customConfig = {};
   try {
@@ -103,4 +99,22 @@ function validateThemeItem(field, key) {
     return null;
   }
   return errMsg.join('\n');
+}
+
+function generateBaseConfig() {
+  const DEFAULT = path.join(__dirname, '..', 'config.json');
+
+  const cache = path.join(osHomedir(), '.tldr');
+  /*eslint-disable no-process-env */
+  const proxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  /*eslint-enable no-process-env */
+  const cacheFolder = path.join(cache, 'cache');
+  const corpusfile = path.join(cacheFolder, 'search-corpus.json');
+  const shortIndexFile = path.join(cacheFolder, 'shortIndex.json');
+  const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
+
+  return Object.assign(
+    { cache, proxy, cacheFolder, corpusfile, shortIndexFile, tempFolder },
+    JSON.parse(fs.readFileSync(DEFAULT))
+  );
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,17 +2,13 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const config = require('./config');
 const utils = require('./utils');
 
 let shortIndex = null;
 
-const pagesPath = path.join(config.get().cache, 'cache');
-const shortIndexFile = path.join(pagesPath, 'shortIndex.json');
-
-function findPage(page, preferredPlatform, preferredLanguage) {
+function findPage(config, page, preferredPlatform, preferredLanguage) {
   // Load the index
-  return getShortIndex()
+  return getShortIndex(config)
     .then((idx) => {
       // First, check whether page is in the index
       if (! (page in idx)) {
@@ -102,16 +98,16 @@ function hasPage(page) {
 }
 
 // Return all commands available in the local cache.
-function commands() {
-  return getShortIndex().then((idx) => {
+function commands(config) {
+  return getShortIndex(config).then((idx) => {
     return Object.keys(idx).sort();
   });
 }
 
 // Return all commands for a given platform.
 // P.S. - The platform 'common' is always included.
-function commandsFor(platform) {
-  return getShortIndex()
+function commandsFor(config, platform) {
+  return getShortIndex(config)
     .then((idx) => {
       let commands = Object.keys(idx)
         .filter((cmd) => {
@@ -125,8 +121,8 @@ function commandsFor(platform) {
 }
 
 // Delete the index file.
-function clearPagesIndex() {
-  return fs.unlink(shortIndexFile)
+function clearPagesIndex(config) {
+  return fs.unlink(config.shortIndexFile)
     .then(() => {
       return clearRuntimeIndex();
     })
@@ -144,46 +140,46 @@ function clearRuntimeIndex() {
   shortIndex = null;
 }
 
-function rebuildPagesIndex() {
-  return clearPagesIndex().then(() => {
-    return getShortIndex();
+function rebuildPagesIndex(config) {
+  return clearPagesIndex(config).then(() => {
+    return getShortIndex(config);
   });
 }
 
 // If the variable is not set, read the file and set it.
 // Else, just return the variable.
-function getShortIndex() {
+function getShortIndex(config) {
   if (shortIndex) {
     return Promise.resolve(shortIndex);
   }
-  return readShortPagesIndex();
+  return readShortPagesIndex(config);
 }
 
 // Read the index file, and load it into memory.
 // If the file does not exist, create the data structure, write the file,
 // and load it into memory.
-function readShortPagesIndex() {
-  return fs.readJson(shortIndexFile)
+function readShortPagesIndex(config) {
+  return fs.readJson(config.shortIndexFile)
     .then((idx) => {
       shortIndex = idx;
       return shortIndex;
     })
     .catch(() => {
       // File is not present; we need to create the index.
-      return buildShortPagesIndex().then((idx) => {
+      return buildShortPagesIndex(config).then((idx) => {
         if (Object.keys(idx).length <= 0) {
           return idx;
         }
         shortIndex = idx;
-        return fs.writeJson(shortIndexFile, shortIndex).then(() => {
+        return fs.writeJson(config.shortIndexFile, shortIndex).then(() => {
           return shortIndex;
         });
       });
     });
 }
 
-function buildShortPagesIndex() {
-  return utils.walk(pagesPath)
+function buildShortPagesIndex(config) {
+  return utils.walk(config.cacheFolder)
     .then((files) => {
       files = files.filter(utils.isPage);
       let reducer = (index, file) => {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,4 +1,3 @@
-const config = require('./config');
 
 module.exports = {
   emptyCache() {
@@ -6,8 +5,8 @@ module.exports = {
 Please run tldr --update`;
   },
 
-  notFound() {
+  notFound(config) {
     return `Page not found.
-If you want to contribute it, feel free to send a pull request to: ` + config.get().pagesRepository;
+If you want to contribute it, feel free to send a pull request to: ` + config.pagesRepository;
   }
 };

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,19 +1,18 @@
 'use strict';
 
 const unzip = require('node-unzip-2');
-const config  = require('./config');
 
 let request = require('request');
 
 // Downloads the zip file from github and extracts it to folder
-exports.download = (path) => {
-  let url = config.get().repository;
+exports.download = (config, path) => {
+  let url = config.repository;
 
   // Creating the extractor
   let extractor = unzip.Extract({ path });
 
   // Setting the proxy if set by config
-  if (config.get().proxy) {
+  if (config.proxy) {
     request = request.defaults({ proxy: config.proxy });
   }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,17 +1,11 @@
 'use strict';
 
 const fs = require('fs-extra');
-const path = require('path');
 const natural = require('natural');
 
-const config = require('./config');
 const utils = require('./utils');
 const index = require('./index');
 const platform = require('./platform');
-
-const CACHE_FOLDER = path.join(config.get().cache, 'cache');
-
-const filepath = CACHE_FOLDER + '/search-corpus.json';
 
 let corpus = {};
 
@@ -112,20 +106,20 @@ let createFileLengths = () => {
   });
 };
 
-let writeCorpus = () => {
+let writeCorpus = (config) => {
   corpus.allTokens = Array.from(corpus.allTokens);
   let json = JSON.stringify(corpus);
-  return fs.writeFile(filepath, json, 'utf8')
+  return fs.writeFile(config.corpusfile, json, 'utf8')
     .then(() => {
-      return Promise.resolve('JSON written to disk at: ' + filepath);
+      return Promise.resolve('JSON written to disk at: ' + config.corpusfile);
     })
     .catch((err) => {
       return Promise.reject(err);
     });
 };
 
-let readCorpus = () => {
-  return fs.readFile(filepath, 'utf8')
+let readCorpus = (config) => {
+  return fs.readFile(config.corpusfile, 'utf8')
     .then((data) => {
       corpus = JSON.parse(data.toString());
       return Promise.resolve();
@@ -191,7 +185,7 @@ exports.printResults = (results, config) => {
   // it lists the available platforms instead.
   // Example: tldr --search print directory tree --os sunos prints:
   //              $ tree (Available on: linux, osx)
-  index.getShortIndex().then((shortIndex) => {
+  index.getShortIndex(config).then((shortIndex) => {
     let outputs = new Set();
     let preferredPlatform = platform.getPreferredPlatform(config);
     results.forEach((elem) => {
@@ -215,8 +209,8 @@ exports.printResults = (results, config) => {
   });
 };
 
-exports.createIndex = () => {
-  return utils.glob(CACHE_FOLDER + '/pages/**/*.md', {})
+exports.createIndex = (config) => {
+  return utils.glob(config.cacheFolder + '/pages/**/*.md', {})
     .then((files) => {
       let promises = [];
       files.forEach((file) => {
@@ -230,7 +224,7 @@ exports.createIndex = () => {
           createInvertedIndex(corpus.allTokens);
           createTfIdf();
           createFileLengths();
-          return writeCorpus();
+          return writeCorpus(config);
         })
         .then(() => {
           return Promise.resolve(corpus);
@@ -242,9 +236,9 @@ exports.createIndex = () => {
     });
 };
 
-exports.getResults = (rawquery) => {
+exports.getResults = (config, rawquery) => {
   query.ranks = [];
-  return readCorpus()
+  return readCorpus(config)
     .then(() => {
       processQuery(rawquery);
       let resultcount = 10;

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -23,14 +23,14 @@ class Tldr {
 
   list(singleColumn) {
     let os = platform.getPreferredPlatformFolder(this.config);
-    index.commandsFor(os)
+    index.commandsFor(this.config, os)
       .then((commands) => {
         this.printPages(commands, singleColumn);
       });
   }
 
   listAll(singleColumn) {
-    index.commands()
+    index.commands(this.config)
       .then((commands) => {
         this.printPages(commands, singleColumn);
       });
@@ -42,7 +42,7 @@ class Tldr {
 
   random(options) {
     let os = platform.getPreferredPlatformFolder(this.config);
-    index.commandsFor(os)
+    index.commandsFor(this.config, os)
       .then((pages) => {
         if (pages.length === 0) {
           console.error(messages.emptyCache());
@@ -59,7 +59,7 @@ class Tldr {
 
   randomExample() {
     let os = platform.getPreferredPlatformFolder(this.config);
-    index.commandsFor(os)
+    index.commandsFor(this.config, os)
       .then((pages) => {
         if (pages.length === 0) {
           console.error(messages.emptyCache());
@@ -78,7 +78,7 @@ class Tldr {
     fs.readFile(file, 'utf8')
       .then((content) => {
         // Getting the shortindex first to populate the shortindex var
-        return index.getShortIndex().then(() => {
+        return index.getShortIndex(this.config).then(() => {
           this.renderContent(content);
         });
       })
@@ -110,7 +110,7 @@ class Tldr {
   updateIndex() {
     const spinner = ora();
     spinner.start('Creating index...');
-    search.createIndex()
+    search.createIndex(this.config)
       .then(() => {
         spinner.succeed();
       })
@@ -120,7 +120,7 @@ class Tldr {
   }
 
   search(keywords) {
-    search.getResults(keywords.join(' '))
+    search.getResults(this.config, keywords.join(' '))
       .then((results) => {
         // TODO: make search into a class also.
         search.printResults(results, this.config);
@@ -160,7 +160,7 @@ class Tldr {
       .then(() => {
         spinner.succeed();
         spinner.start('Creating index...');
-        return search.createIndex();
+        return search.createIndex(this.config);
       })
       .then(() => {
         spinner.succeed();
@@ -169,7 +169,7 @@ class Tldr {
       })
       .then((content) => {
         if (!content) {
-          console.error(messages.notFound());
+          console.error(messages.notFound(this.config));
           return exit(1);
         }
         this.checkStale();

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -5,6 +5,7 @@ const config = require('../lib/config');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
+const os = require('os');
 const fs = require('fs-extra');
 const index = require('../lib/index');
 const remote = require('../lib/remote');
@@ -37,20 +38,15 @@ describe('Cache', () => {
       this.cacheFolder = path.join(config.get().cache, 'cache');
     });
 
-    it('should use randomly created temp folder', () => {
-      const count = 16;
+    it('should created a temp folder', () => {
       const cache = new Cache(config.get());
-      return Promise.all(Array.from({ length: count }).map(() => {
-        return cache.update();
-      })).then(() => {
-        let calls = fs.ensureDir.getCalls().filter((call) => {
+
+      return cache.update().then(()=>{
+        const calls = fs.ensureDir.getCalls().filter((call) => {
           return !call.calledWith(this.cacheFolder);
         });
-        calls.should.have.length(count);
-        let tempFolders = calls.map((call) => {
-          return call.args[0];
-        });
-        tempFolders.should.have.length(new Set(tempFolders).size);
+        calls.should.have.length(1);
+        calls[0].args[0].should.startWith(os.tmpdir());
       });
     });
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -4,35 +4,33 @@ const fs = require('fs');
 const sinon = require('sinon');
 const config = require('../lib/config');
 
-describe('Config', () => {
-
-  const DEFAULT =
+const DEFAULT =
 `
 {
-  "repository": "http://tldr-pages.github.io/assets/tldr.zip"
+"repository": "http://tldr-pages.github.io/assets/tldr.zip"
 }`;
 
-  const CUSTOM =
+const CUSTOM =
 `
 {
-  "repository": "http://myrepo/assets/tldr.zip"
+"repository": "http://myrepo/assets/tldr.zip"
 }`;
 
-  const CUSTOM_INVALID =
+const CUSTOM_INVALID =
 `
 {
-  "themes": {
-    "simple": {
-      "commandName": "bold,underline",
-      "mainDescription": "#876992",
-      "exampleDescription": "",
-      "exampleCode": "",
-      "exampleToken": "underline"
-    }
+"themes": {
+  "simple": {
+    "commandName": "bold,underline",
+    "mainDescription": "#876992",
+    "exampleDescription": "",
+    "exampleCode": "",
+    "exampleToken": "underline"
   }
+}
 }`;
 
-
+describe('Config', () => {
   beforeEach(() => {
     sinon.stub(fs, 'readFileSync');
   });
@@ -58,5 +56,23 @@ describe('Config', () => {
     fs.readFileSync.onCall(1).returns(CUSTOM_INVALID);
     config.get.should.throw(/Invalid theme value/);
   });
+});
 
+describe('Config construction', () => {
+  beforeEach(() => {
+    sinon.stub(fs, 'readFileSync');
+    fs.readFileSync.returns(DEFAULT);
+  });
+
+  afterEach(() => {
+    fs.readFileSync.restore();
+  });
+
+  it('should generate randomly salted temp directory paths', () => {
+    const length = 16;
+    const tempPaths = Array.from({ length }, () => {
+      return config.get().tempFolder;
+    });
+    tempPaths.should.have.length(new Set(tempPaths).size);
+  });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,8 @@ const utils = require('../lib/utils');
 const sinon = require('sinon');
 const should = require('should');
 
+const config = require('../lib/config').get();
+
 const pages = [
   '/index.json',
   '/pages/linux/apk.md',
@@ -31,7 +33,7 @@ describe('Index building', () => {
   beforeEach(() => {
     sinon.stub(fs, 'readJson').rejects('dummy error');
     sinon.stub(fs, 'writeJson').resolves('');
-    return index.rebuildPagesIndex();
+    return index.rebuildPagesIndex(config);
   });
 
   describe('failure', () => {
@@ -79,84 +81,84 @@ describe('Index', () => {
 
   describe('findPage()', () => {
     it('should find Linux platform for apk command for Chinese', () => {
-      return index.findPage('apk', 'linux', 'zh')
+      return index.findPage(config, 'apk', 'linux', 'zh')
         .then((folder) => {
           return folder.should.equal('pages.zh/linux');
         });
     });
 
     it('should find Linux platform for apk command for Chinese given Windows', () => {
-      return index.findPage('apk', 'windows', 'zh')
+      return index.findPage(config, 'apk', 'windows', 'zh')
         .then((folder) => {
           return folder.should.equal('pages.zh/linux');
         });
     });
 
     it('should find Linux platform for dd command', () => {
-      return index.findPage('dd', 'linux', 'en')
+      return index.findPage(config, 'dd', 'linux', 'en')
         .then((folder) => {
           return folder.should.equal('pages/linux');
         });
     });
 
     it('should find platform common for cp command for English', () => {
-      return index.findPage('cp', 'linux', 'en')
+      return index.findPage(config, 'cp', 'linux', 'en')
         .then((folder) => {
           return folder.should.equal('pages/common');
         });
     });
 
     it('should find platform common for cp command for Tamil', () => {
-      return index.findPage('cp', 'linux', 'ta')
+      return index.findPage(config, 'cp', 'linux', 'ta')
         .then((folder) => {
           return folder.should.equal('pages.ta/common');
         });
     });
 
     it('should find platform common for cp command for Italian', () => {
-      return index.findPage('cp', 'linux', 'it')
+      return index.findPage(config, 'cp', 'linux', 'it')
         .then((folder) => {
           return folder.should.equal('pages.it/common');
         });
     });
 
     it('should find platform common for cp command for Italian given Windows', () => {
-      return index.findPage('cp', 'windows', 'it')
+      return index.findPage(config, 'cp', 'windows', 'it')
         .then((folder) => {
           return folder.should.equal('pages.it/common');
         });
     });
 
     it('should find platform common for ls command for Italian', () => {
-      return index.findPage('ls', 'linux', 'it')
+      return index.findPage(config, 'ls', 'linux', 'it')
         .then((folder) => {
           return folder.should.equal('pages/common');
         });
     });
 
     it('should find platform common for cp command for Italian given common platform', () => {
-      return index.findPage('cp', 'common', 'it')
+      return index.findPage(config, 'cp', 'common', 'it')
         .then((folder) => {
           return folder.should.equal('pages.it/common');
         });
     });
 
     it('should find platform common for cp command for English given a bad language', () => {
-      return index.findPage('cp', 'linux', 'notexist')
+      return index.findPage(config, 'cp', 'linux', 'notexist')
         .then((folder) => {
           return folder.should.equal('pages/common');
         });
     });
 
     it('should find platform for svcs command on Linux', () => {
-      return index.findPage('svcs', 'linux', 'en')
+      return index.findPage(config, 'svcs', 'linux', 'en')
         .then((folder) => {
           return folder.should.equal('pages/sunos');
         });
     });
 
     it('should not find platform for non-existing command', () => {
-      return index.findPage('qwerty', 'linux', 'en')
+      return index.findPage(config, 'qwerty', 'linux', 'en')
         .then((folder) => {
           return should.not.exist(folder);
         });
@@ -164,7 +166,7 @@ describe('Index', () => {
   });
 
   it('should return correct list of all pages', () => {
-    return index.commands()
+    return index.commands(config)
       .then((commands) => {
         commands.should.deepEqual([
           'apk', 'cp', 'dd', 'du', 'git', 'ln', 'ls', 'svcs', 'top'
@@ -174,7 +176,7 @@ describe('Index', () => {
 
   describe('commandsFor()', () => {
     it('should return correct list of pages for Linux', () => {
-      return index.commandsFor('linux')
+      return index.commandsFor(config, 'linux')
         .then((commands) => {
           commands.should.deepEqual([
             'apk', 'cp', 'dd', 'du', 'git', 'ln', 'ls', 'top'
@@ -183,7 +185,7 @@ describe('Index', () => {
     });
 
     it('should return correct list of pages for OSX', () => {
-      return index.commandsFor('osx')
+      return index.commandsFor(config, 'osx')
         .then((commands) => {
           commands.should.deepEqual([
             'cp', 'dd', 'du', 'git', 'ln', 'ls', 'top'
@@ -192,7 +194,7 @@ describe('Index', () => {
     });
 
     it('should return correct list of pages for SunOS', () => {
-      return index.commandsFor('sunos')
+      return index.commandsFor(config, 'sunos')
         .then((commands) => {
           commands.should.deepEqual([
             'cp', 'dd', 'du', 'git', 'ln', 'ls', 'svcs'
@@ -202,7 +204,7 @@ describe('Index', () => {
   });
 
   it('should return correct short index on getShortIndex()', () => {
-    return index.getShortIndex()
+    return index.getShortIndex(config)
       .then((idx) => {
         idx.should.deepEqual({
           apk: {targets: [{language: 'en', os: 'linux'}, {language: 'zh', os: 'linux'}]},


### PR DESCRIPTION
## Description

Now at runtime only `bin/tldr` depends on `config.js`. Which then passes
the result to the rest of the app. Before this, the function was called
multiple times, resulting in excessive fs calls just to get one value
out. This will hopefully make the tool faster and easier to write tests.

Update "should use randomly created temp folder" to become "should
created a temp folder" in `cache.spec.js`. And add "should generate
randomly salted temp directory paths" in `config.spec.js`. As config now
has the responsibility of defining the temp dir location.

Update `index.spec.js` and `search.spec.js` to pass config to methods
that now depend on it.

**Before:**

![before](https://user-images.githubusercontent.com/20130059/79822978-661b1d80-838a-11ea-9368-56dbc3cfdb04.png)

**After:**

![after](https://user-images.githubusercontent.com/20130059/79822973-63b8c380-838a-11ea-87a3-90fa214067a1.png)

<small>(please excuse the `bin/tldr.js` madge wouldn't reconginse the extensionless file as Javascript)</small>

### Why

I want to make some further contributions. And I felt it would make it easier
to contribute if the config was more central in defining certain variables.
While making it's interface dependants require injection instead of importing
it throughout the application. For example this approach will enable writing
future tests that can avoid depending on a globally installed version
`~/.tldr` directory

## Checklist

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
