### PR TITLE
Put caption for README image onto its own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 A `Node.js` based command-line client for [tldr](https://github.com/tldr-pages/tldr).
 
 ![tldr screenshot](screenshot.png)
+
 *tldr-node-client's output for the `tar` page, using a custom color theme*
 
 ## Installing


### PR DESCRIPTION
## Description

Caption on the first image in the README was not on its own line, so the first bit of it (`tldr-node-`) was appearing next to the image for me with the rest of the sentence then on the line under the image. This fixes it so that the caption appears on its own line.

