### PR TITLE
 Add gitattributes to force lf eol in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Description

This makes it so that regardless of a user's settings in git, always use LF line endings. If this is not set, then a user on Windows, when they do git clone, might have a repo where all files have the CRLF line ending, which will cause the linter to fail, which can be confusing to an end user.

Once this is merged, I will update #303 to include a windows build target in the github action (as right now, it would fail without normalizing line endings, see https://github.com/MasterOdin/tldr-node-client/runs/754519436?check_suite_focus=true.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] All tests passing (`npm run test:all`)
