### PR TITLE
fix running tests under windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # todo: windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [10.x, 12.x, 13.x, 14.x]
 
     steps:
@@ -21,7 +21,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}
       with:
         access_token: ${{ github.token }}
-        
+
     - uses: actions/checkout@v2
 
     - name: Cache node modules

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,26 +8,26 @@ const sinon = require('sinon');
 const should = require('should');
 
 const pages = [
-  '/index.json',
-  '/pages/linux/apk.md',
-  '/pages.zh/linux/apk.md',
-  '/pages/common/cp.md',
-  '/pages.it/common/cp.md',
-  '/pages.ta/common/cp.md',
-  '/pages/common/git.md',
-  '/pages/common/ln.md',
-  '/pages/common/ls.md',
-  '/pages/linux/dd.md',
-  '/pages/linux/du.md',
-  '/pages/linux/top.md',
-  '/pages/osx/dd.md',
-  '/pages/osx/du.md',
-  '/pages/osx/top.md',
-  '/pages/sunos/dd.md',
-  '/pages/sunos/du.md',
-  '/pages/sunos/svcs.md'
+  ['/index.json'],
+  ['/pages', 'linux', 'apk.md'],
+  ['/pages.zh', 'linux', 'apk.md'],
+  ['/pages', 'common', 'cp.md'],
+  ['/pages.it', 'common', 'cp.md'],
+  ['/pages.ta', 'common', 'cp.md'],
+  ['/pages', 'common', 'git.md'],
+  ['/pages', 'common', 'ln.md'],
+  ['/pages', 'common', 'ls.md'],
+  ['/pages', 'linux', 'dd.md'],
+  ['/pages', 'linux', 'du.md'],
+  ['/pages', 'linux', 'top.md'],
+  ['/pages', 'osx', 'dd.md'],
+  ['/pages', 'osx', 'du.md'],
+  ['/pages', 'osx', 'top.md'],
+  ['/pages', 'sunos', 'dd.md'],
+  ['/pages', 'sunos', 'du.md'],
+  ['/pages', 'sunos', 'svcs.md']
 ].map((x) => {
-  return path.join(x);
+  return path.join(...x);
 });
 
 describe('Index building', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const path = require('path');
 const index = require('../lib/index');
 const utils = require('../lib/utils');
 const sinon = require('sinon');
@@ -25,7 +26,9 @@ const pages = [
   '/pages/sunos/dd.md',
   '/pages/sunos/du.md',
   '/pages/sunos/svcs.md'
-];
+].map((x) => {
+  return path.join(x);
+});
 
 describe('Index building', () => {
   beforeEach(() => {
@@ -81,77 +84,77 @@ describe('Index', () => {
     it('should find Linux platform for apk command for Chinese', () => {
       return index.findPage('apk', 'linux', 'zh')
         .then((folder) => {
-          return folder.should.equal('pages.zh/linux');
+          return folder.should.equal(path.join('pages.zh', 'linux'));
         });
     });
 
     it('should find Linux platform for apk command for Chinese given Windows', () => {
       return index.findPage('apk', 'windows', 'zh')
         .then((folder) => {
-          return folder.should.equal('pages.zh/linux');
+          return folder.should.equal(path.join('pages.zh', 'linux'));
         });
     });
 
     it('should find Linux platform for dd command', () => {
       return index.findPage('dd', 'linux', 'en')
         .then((folder) => {
-          return folder.should.equal('pages/linux');
+          return folder.should.equal(path.join('pages', 'linux'));
         });
     });
 
     it('should find platform common for cp command for English', () => {
       return index.findPage('cp', 'linux', 'en')
         .then((folder) => {
-          return folder.should.equal('pages/common');
+          return folder.should.equal(path.join('pages', 'common'));
         });
     });
 
     it('should find platform common for cp command for Tamil', () => {
       return index.findPage('cp', 'linux', 'ta')
         .then((folder) => {
-          return folder.should.equal('pages.ta/common');
+          return folder.should.equal(path.join('pages.ta', 'common'));
         });
     });
 
     it('should find platform common for cp command for Italian', () => {
       return index.findPage('cp', 'linux', 'it')
         .then((folder) => {
-          return folder.should.equal('pages.it/common');
+          return folder.should.equal(path.join('pages.it', 'common'));
         });
     });
 
     it('should find platform common for cp command for Italian given Windows', () => {
       return index.findPage('cp', 'windows', 'it')
         .then((folder) => {
-          return folder.should.equal('pages.it/common');
+          return folder.should.equal(path.join('pages.it', 'common'));
         });
     });
 
     it('should find platform common for ls command for Italian', () => {
       return index.findPage('ls', 'linux', 'it')
         .then((folder) => {
-          return folder.should.equal('pages/common');
+          return folder.should.equal(path.join('pages', 'common'));
         });
     });
 
     it('should find platform common for cp command for Italian given common platform', () => {
       return index.findPage('cp', 'common', 'it')
         .then((folder) => {
-          return folder.should.equal('pages.it/common');
+          return folder.should.equal(path.join('pages.it', 'common'));
         });
     });
 
     it('should find platform common for cp command for English given a bad language', () => {
       return index.findPage('cp', 'linux', 'notexist')
         .then((folder) => {
-          return folder.should.equal('pages/common');
+          return folder.should.equal(path.join('pages', 'common'));
         });
     });
 
     it('should find platform for svcs command on Linux', () => {
       return index.findPage('svcs', 'linux', 'en')
         .then((folder) => {
-          return folder.should.equal('pages/sunos');
+          return folder.should.equal(path.join('pages', 'sunos'));
         });
     });
 


### PR DESCRIPTION
Recreating #308 as my fork got messed up there. I've made the suggested changes from that PR here.

## Description

The tests used a linux path separator for referencing things on the filesystem, except that then uses path.sep under the hood for path splitting, which is / on *unix and \\ on windows. Instead of hard-coding the separator, we can use path.join instead which will give us the right seperator.

Closes #305 

Testing on windows is activated under github actions.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] All tests passing (`npm run test:all`)
