### PR TITLE
Prevents 'Cannot read property 'catch' of null' error when tldr is invoked without arguments

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -112,8 +112,9 @@ if (program.list) {
 if (p === null) {
   program.outputHelp();
   process.exitCode = 1;
+} else {
+  p.catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }
-p.catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});


### PR DESCRIPTION
## Description
atm if you invoke tldr without any arguments you see this error thrown at the end:

```
/usr/local/lib/node_modules/tldr/bin/tldr:116
p.catch((err) => {
  ^

TypeError: Cannot read property 'catch' of null
    at Object.<anonymous> (/usr/local/lib/node_modules/tldr/bin/tldr:116:3)
    at Module._compile (node:internal/modules/cjs/loader:1102:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1131:10)
    at Module.load (node:internal/modules/cjs/loader:967:32)
    at Function.Module._load (node:internal/modules/cjs/loader:807:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:4
```

this change prevents the error. not sure what test to add for this as `tldr` without arguments already exits non-zero.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
