### PR TITLE
fix: make version short flag spec compliant

### DIFF
--- a/bin/tldr
+++ b/bin/tldr
@@ -7,7 +7,7 @@ const config = require('../lib/config');
 const platform = require('../lib/platform');
 
 program
-  .version(pkg.version)
+  .version(pkg.version, '-v, --version')
   .description(pkg.description)
   .usage('command [options]')
   //


### PR DESCRIPTION
## Description

The [client specification](https://github.com/tldr-pages/tldr/blob/master/CLIENT-SPECIFICATION.md) indicates that [CLI options](https://github.com/tldr-pages/tldr/blob/master/CLIENT-SPECIFICATION.md#arguments) should be `-v, --version` for specifying the version. The node client was doing `-V, --version` as that's the commander default. This changes the node client to instead use `-v, --version` instead, making it spec compliant.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
