### PR TITLE
Remove flaky test

### DIFF
--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -12,21 +12,6 @@ const platform = require('../lib/platform');
 
 
 describe('Cache', () => {
-  it('should return a positive number on lastUpdate', function () {
-    // To allow setting timeout of 30 secs
-    // eslint-disable-next-line no-magic-numbers
-    this.timeout(30000);
-    const cache = new Cache(config.get());
-    return cache.update()
-      .then(() => {
-        return cache.lastUpdated();
-      })
-      .then((stats) => {
-        should.exist(stats);
-        stats.mtime.should.be.aboveOrEqual(0);
-      });
-  });
-
   describe('update()', () => {
     beforeEach(() => {
       sinon.spy(fs, 'ensureDir');

--- a/test/functional-test.sh
+++ b/test/functional-test.sh
@@ -16,6 +16,7 @@ function tldr-render-pages {
   tldr --list-all
 }
 
+tldr --update && \
 tldr --render $HOME/.tldr/cache/pages/common/ssh.md && \
 tldr --update && tldr-render-pages && \
 tldr --clear-cache && \


### PR DESCRIPTION
## Description
The timeout of 30s was never enough, and this test
would fail in CI all the time.

Increasing the timeout does not make much sense as it will just
slow down things more. We should ideally mock the network to have
reliable unit tests, otherwise they are technically component tests.

Cache updates aren't a major functionality, so we just remove the test
to have a more robust CI pipeline.


## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
~- [ ] Created tests, if possible~
- [x] All tests passing (`npm run test:all`)
~- [ ] Extended the README / documentation, if necessary~
