### PR TITLE
Add command line option "--windows"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ npm install -g tldr
 To see tldr pages:
 
 - `tldr <command>` show examples for this command
-- `tldr <command> --os=<platform>` show command page for the given platform (`linux`, `osx`, `sunos`)
+- `tldr <command> --os=<platform>` show command page for the given platform (`linux`, `osx`, `sunos`, `windows`)
 - `tldr --search "<query>"` search all pages for the query
 - `tldr --linux <command>` show command page for Linux
 - `tldr --osx <command>` show command page for OSX
 - `tldr --sunos <command>` show command page for SunOS
+- `tldr --windows <command>` show command page for Windows
 - `tldr --list` show all pages for current platform
 - `tldr --list-all` show all available pages
 - `tldr --random` show a page at random

--- a/bin/completion/bash/tldr
+++ b/bin/completion/bash/tldr
@@ -2,7 +2,7 @@
 
 BUILTIN_THEMES="single base16 ocean"
 
-OS_TYPES="linux osx sunos"
+OS_TYPES="linux osx sunos windows"
 
 OPTIONS='-V
 --version
@@ -24,6 +24,7 @@ OPTIONS='-V
 --linux
 --osx
 --sunos
+--windows
 -t
 --theme
 -s

--- a/bin/completion/zsh/_tldr
+++ b/bin/completion/zsh/_tldr
@@ -2,7 +2,7 @@
 
 local -a pages oses
 pages=$(tldr -a1)
-oses='( linux osx sunos )'
+oses='( linux osx sunos windows )'
 
 _arguments \
   '(- *)'{-h,--help}'[show help]' \
@@ -19,6 +19,7 @@ _arguments \
   '--linux[override operating system with Linux]' \
   '--osx[override operating system with OSX]' \
   '--sunos[override operating system with SunOS]' \
+  '--windows[override operating system with Windows]' \
   '(- *)'{-u,--update}'[update local cache]' \
   '(- *)'{-c,--clear-cache}'[clear local cache]' \
   "*:page:(${pages})" && return 0

--- a/bin/tldr
+++ b/bin/tldr
@@ -20,10 +20,11 @@ program
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
   .option('-m, --markdown', 'Output in markdown format')
-  .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos]')
+  .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos, windows]')
   .option('--linux', 'Override the operating system with Linux')
   .option('--osx', 'Override the operating system with OSX')
   .option('--sunos', 'Override the operating system with SunOS')
+  .option('--windows', 'Override the operating system with Windows')
   .option('-t, --theme [theme]', 'Color theme (simple, base16, ocean)')
   .option('-s, --search [keywords]', 'Search pages using keywords')
   //
@@ -69,6 +70,10 @@ if (program.osx) {
 
 if (program.sunos) {
   program.os = 'sunos';
+}
+
+if (program.windows) {
+  program.os = 'windows';
 }
 
 let cfg = config.get();

--- a/test/functional-test.sh
+++ b/test/functional-test.sh
@@ -10,6 +10,7 @@ function tldr-render-pages {
   tldr du --os=osx && \
   tldr du --os=linux --markdown && \
   tldr du --os=osx --markdown && \
+  tldr du --os=windows --markdown && \
   LANG= tldr --random && \
   LANG= tldr --random-example && \
   tldr --list && \


### PR DESCRIPTION
## Description
I added the command line option "--windows", since the functionality already was there, just the option was missing.

## Checklist

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [ ] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary

I didn't modify any tests, since I don't know what I should change. Also I'm sorry if I made any mistakes, I hardly know any javascript.