### PR TITLE
Fix #341

### DIFF
--- a/bin/completion/zsh/_tldr
+++ b/bin/completion/zsh/_tldr
@@ -6,7 +6,7 @@ oses='( linux osx sunos windows )'
 
 _arguments \
   '(- *)'{-h,--help}'[show help]' \
-  '(- *)'{-v,--version}'[show version number]' \
+  '(- *)'{-v,--version}'[display version]' \
   '(- *)'{-l,--list}'[list all commands for chosen platform]' \
   '(- *)'{-a,--list-all}'[list all commands]' \
   '(- *)'{-1,--single-column}'[list one command per line (used with -l or -a)]' \

--- a/bin/tldr
+++ b/bin/tldr
@@ -8,7 +8,8 @@ const platform = require('../lib/platform');
 const { TldrError } = require('../lib/errors');
 
 program
-  .version(pkg.version, '-v, --version')
+  .version(pkg.version, '-v, --version', 'Display version')
+  .helpOption('-h, --help', 'Show this help message')
   .description(pkg.description)
   .usage('command [options]')
   //


### PR DESCRIPTION
## Description
Fix #341, which is to remove ambiguous descriptions with clearer ones.
- `-v, --version`: `output the version number` -> `Display version`
- `-h, --help`: `display help for command` -> `Show this help message`

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
