### PR TITLE
Serve `tldr.zip` using HTTPS

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "pagesRepository": "https://github.com/tldr-pages/tldr",
-  "repository": "https://tldr-pages.github.io/assets/tldr.zip",
+  "repository": "https://tldr.sh/assets/tldr.zip",
   "themes": {
     "simple": {
       "commandName": "bold, underline",


### PR DESCRIPTION
## Description

Update remote repo to https://tldr.sh/assets/tldr.zip because https://tldr-pages.github.io redirects to http://tldr.sh (note the insecure transport)!

Please explain the changes you made here.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
