### PR TITLE
Skip update when page not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ As a contributor, you can also point to your own fork containing the `tldr.zip` 
 }
 ```
 
-If you want to prevent that a cache update is performed each time no page is found for a command, then
+By default, a cache update is performed anytime a page is not found for a command. To prevent this behavior,
 you can set the configuration variable `skipUpdateWhenPageNotFound` to `true` (defaults to `false`):
 
 ```js

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ As a contributor, you can also point to your own fork containing the `tldr.zip` 
 }
 ```
 
+To prevent that a cache update is performed each time no page is found the variable `skipUpdateWhenPageNotFound` can be set to `true`:
+```js
+{
+  "skipUpdateWhenPageNotFound": true,
+}
+```
+
 ## Command-line Autocompletion
 
 Currently we only support command-line autocompletion for zsh

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ As a contributor, you can also point to your own fork containing the `tldr.zip` 
 
 ```js
 {
-  "repository" : "http://myrepo/assets/tldr.zip"
+  "repository": "http://myrepo/assets/tldr.zip"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ As a contributor, you can also point to your own fork containing the `tldr.zip` 
 }
 ```
 
-To prevent that a cache update is performed each time no page is found the variable `skipUpdateWhenPageNotFound` can be set to `true`:
+If you want to prevent that a cache update is performed each time no page is found for a command, then
+you can set configuration variable `skipUpdateWhenPageNotFound` to the value `true` 
+(the default value is `false`):
+
 ```js
 {
   "skipUpdateWhenPageNotFound": true

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ As a contributor, you can also point to your own fork containing the `tldr.zip` 
 
 ```js
 {
-  "repository" : "http://myrepo/assets/tldr.zip",
+  "repository" : "http://myrepo/assets/tldr.zip"
 }
 ```
 
 To prevent that a cache update is performed each time no page is found the variable `skipUpdateWhenPageNotFound` can be set to `true`:
 ```js
 {
-  "skipUpdateWhenPageNotFound": true,
+  "skipUpdateWhenPageNotFound": true
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "pagesRepository": "https://github.com/tldr-pages/tldr",
   "repository": "https://tldr.sh/assets/tldr.zip",
+  "skipUpdateWhenPageNotFound": false,
   "themes": {
     "simple": {
       "commandName": "bold, underline",

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -129,7 +129,7 @@ class Tldr {
       .then((content) => {
         // If found in first try, render it
         if (!content) {
-          // If not found, try to update
+          // If not found, try to update cache unless setting is disabled
           if (this.config.skipUpdateWhenPageNotFound === true) {
             return '';
           }

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -129,7 +129,7 @@ class Tldr {
       .then((content) => {
         // If found in first try, render it
         if (!content) {
-          // If not found, try to update cache unless setting is disabled
+          // If not found, try to update cache unless user explicitly wants to skip
           if (this.config.skipUpdateWhenPageNotFound === true) {
             return '';
           }

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -131,7 +131,6 @@ class Tldr {
         if (!content) {
           // If not found, try to update
           if (this.config.skipUpdateWhenPageNotFound === true) {
-            console.log('Skipping update of cache because option skipUpdateWhenPageNotFound is set.');
             return '';
           }
           return spinningPromise('Page not found. Updating cache...', () => {

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -130,6 +130,10 @@ class Tldr {
         // If found in first try, render it
         if (!content) {
           // If not found, try to update
+          if (this.config.skipUpdateWhenPageNotFound === true) {
+            console.log('Skipping update of cache because option skipUpdateWhenPageNotFound is set.');
+            return '';
+          }
           return spinningPromise('Page not found. Updating cache...', () => {
             return this.cache.update();
           })


### PR DESCRIPTION
## Description
Introduced new configuration variable `skipUpdateWhenPageNotFound` for `config.json` or `.tldrrc`. When this variable is set to `true`, then upon a cache miss no (lengthy) cache update will be performed (on slower machines like a Raspberry Pi this update can take more than four minutes). 

## Checklist

Please review this checklist before submitting a pull request.

- [X] Code compiles correctly
- [ ] Created tests, if possible
- [X] All tests passing (`npm run test:all`)
- [X] Extended the README / documentation, if necessary
