### PR TITLE
Add win32 to platform.js

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -7,7 +7,8 @@ const folders = {
   'darwin': 'osx',
   'linux': 'linux',
   'sunos': 'sunos',
-  'windows': 'windows'
+  'windows': 'windows',
+  'win32': 'windows'
 };
 
 // Check if the platform is there in the list of platforms or not


### PR DESCRIPTION
Adding 'win32':'windows' key-value in the platform.js file allows to detect the system platform as part of the default configuration (for windows users).  The 'win32' key is provided by the ['os' core module api](https://nodejs.org/api/os.html#osplatform).

## Description
I've added a key-value pair: `"win32":"windows"` inside the `folders` object in the /lib/plaform.js file, this change allows _tldr-node-client_ to identify the windows platform (as default configuration). It solves the issue #368 .
## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
