### PR TITLE
rename `--os`/`-o` to `--platform`/`-p`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install -g tldr
 To see tldr pages:
 
 - `tldr <command>` show examples for this command
-- `tldr <command> --os=<platform>` show command page for the given platform (`linux`, `osx`, `sunos`, `windows`)
+- `tldr <command> --platform=<platform>` show command page for the given platform (`android`, `common`, `linux`, `osx`, `sunos`, `windows`)
 - `tldr --search "<query>"` search all pages for the query
 - `tldr --linux <command>` show command page for Linux
 - `tldr --osx <command>` show command page for OSX
@@ -91,7 +91,7 @@ you can put it in the config file:
 The default platform value can be overwritten with command-line option:
 
 ```shell
-tldr du --os=osx
+tldr du --platform=osx
 ```
 
 As a contributor, you can also point to your own fork containing the `tldr.zip` file. The file is just a zipped version of the entire tldr repo:

--- a/bin/completion/bash/tldr
+++ b/bin/completion/bash/tldr
@@ -2,7 +2,7 @@
 
 BUILTIN_THEMES="single base16 ocean"
 
-OS_TYPES="linux osx sunos windows"
+PLATFORMS="android common linux osx sunos windows"
 
 OPTIONS='-v
 --version
@@ -20,7 +20,8 @@ OPTIONS='-v
 --render
 -m
 --markdown
--o
+-p
+--platform
 --linux
 --osx
 --sunos
@@ -56,7 +57,7 @@ function _tldr_autocomplete {
         COMPREPLY=(`compgen -f $cur`)
         ;;
 
-      -o|--os)
+      -p|--platform)
         COMPREPLY=(`compgen -W "$OS_TYPES" $cur`)
         ;;
 

--- a/bin/completion/zsh/_tldr
+++ b/bin/completion/zsh/_tldr
@@ -2,7 +2,7 @@
 
 local -a pages oses
 pages=$(tldr -a1)
-oses='( linux osx sunos windows )'
+platforms='( android common linux osx sunos windows )'
 
 _arguments \
   '(- *)'{-h,--help}'[show help]' \
@@ -15,7 +15,7 @@ _arguments \
   '(- *)'{-e,--random-example}'[show a random example]' \
   '(- *)'{-m,--markdown}'[show the original markdown format page]' \
   '(-f --render)'{-f,--render}'[render a specific markdown file]:markdown file:_files -/' \
-  '(-o --os)'{-o,--os}"[override operating system]:os:${oses}" \
+  '(-p --platform)'{-p,--platform}"[override platform]:platform:${platforms}" \
   '--linux[override operating system with Linux]' \
   '--osx[override operating system with OSX]' \
   '--sunos[override operating system with SunOS]' \

--- a/bin/tldr
+++ b/bin/tldr
@@ -22,7 +22,7 @@ program
   .option('-e, --random-example', 'Show a random example')
   .option('-f, --render [file]', 'Render a specific markdown [file]')
   .option('-m, --markdown', 'Output in markdown format')
-  .option('-o, --os [type]', 'Override the operating system [linux, osx, sunos, windows]')
+  .option('-p, --platform [platform]', 'Override the platform [android, common, linux, osx, sunos, windows]')
   .option('--linux', 'Override the operating system with Linux')
   .option('--osx', 'Override the operating system with OSX')
   .option('--sunos', 'Override the operating system with SunOS')
@@ -39,7 +39,7 @@ const help = `
   Examples:
 
     $ tldr tar
-    $ tldr du --os=linux
+    $ tldr du --platform=linux
     $ tldr --search "create symbolic link to file"
     $ tldr --list
     $ tldr --list-all
@@ -63,25 +63,25 @@ program.on('--help', () => {
 program.parse(process.argv);
 
 if (program.linux) {
-  program.os = 'linux';
+  program.platform = 'linux';
 }
 
 if (program.osx) {
-  program.os = 'osx';
+  program.platform = 'osx';
 }
 
 if (program.sunos) {
-  program.os = 'sunos';
+  program.platform = 'sunos';
 }
 
 if (program.windows) {
-  program.os = 'windows';
+  program.platform = 'windows';
 }
 
 let cfg = config.get();
-if (program.os) {
-  if (platform.isSupported(program.os)) {
-    cfg.platform = program.os;
+if (program.platform) {
+  if (platform.isSupported(program.platform)) {
+    cfg.platform = program.platform;
   }
 }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -189,7 +189,7 @@ exports.printResults = (results, config) => {
   // Prints the passed results to the console.
   // If the command is not available for the current platform,
   // it lists the available platforms instead.
-  // Example: tldr --search print directory tree --os sunos prints:
+  // Example: tldr --search print directory tree --platform sunos prints:
   //              $ tree (Available on: linux, osx)
   index.getShortIndex().then((shortIndex) => {
     let outputs = new Set();

--- a/test/functional-test.sh
+++ b/test/functional-test.sh
@@ -6,11 +6,11 @@ alias tldr="node bin/tldr"
 
 function tldr-render-pages {
   tldr zip && \
-  tldr du --os=linux && \
-  tldr du --os=osx && \
-  tldr du --os=linux --markdown && \
-  tldr du --os=osx --markdown && \
-  tldr du --os=windows --markdown && \
+  tldr du --platform=linux && \
+  tldr du --platform=osx && \
+  tldr du --platform=linux --markdown && \
+  tldr du --platform=osx --markdown && \
+  tldr du --platform=windows --markdown && \
   LANG= tldr --random && \
   LANG= tldr --random-example && \
   tldr --list && \


### PR DESCRIPTION
this has already caused a lot of confusion (https://github.com/tldr-pages/tldr/pull/6869, https://github.com/tldr-pages/tldr/pull/9252#pullrequestreview-1152328588, …), is not standard (https://github.com/tldr-pages/tldr/blob/9ac1ffd5ca55f977da63d954788be5c463def51a/CLIENT-SPECIFICATION.md#arguments) and has already been fixed in other clients (https://github.com/dbrgn/tealdeer/issues/209)

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
