### PR TITLE
package.json: Add funding information

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
       "pre-commit": "npm run lint",
       "pre-push": "npm run test:quiet"
     }
+  },
+  "funding":{
+    "type": "liberapay",
+    "url": "https://liberapay.com/tldr-pages"
   }
 }


### PR DESCRIPTION
Signed-off-by: K.B.Dharun Krishna <kbdharunkrishna@gmail.com>

## Description

Adding Liberapay to funding information in `package.json` to show up during `npm install` and `npm fund` commands. Ref: https://github.com/npm/rfcs/blob/main/implemented/0017-add-funding-support.md

![image](https://user-images.githubusercontent.com/26346867/209488247-54e753f3-6ef7-41fa-99aa-5815a86d768d.png)

## Checklist

Please review this checklist before submitting a pull request.

- [ ] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)

```powershell
 npm run test:all

> tldr@3.3.8 test:all
> npm run lint && npm test && npm run test:functional


> tldr@3.3.8 lint
> eslint lib test bin/tldr

'eslint' is not recognized as an internal or external command,
operable program or batch file.
```

- [ ] Extended the README / documentation, if necessary
