### PR TITLE
Add node 16 and 18 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 13.x, 14.x, 16.x, 18.x]
 
     steps:
     - name: Cancel Previous Runs


### PR DESCRIPTION
## Description

PR adds node 16 and 18 to our test matrix to ensure the client works against the latest LTS releases. Unlike #352, I chose not to bump the minimum engine version as the codebase given that not yet using anything that wouldn't work against node 10.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
