### PR TITLE
Drop support for node 12 and lower

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - name: Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "homepage": "http://tldr-pages.github.io",
   "engines": {
-    "node": ">=6.12.0"
+    "node": ">=14"
   },
   "main": "bin/tldr",
   "files": [


### PR DESCRIPTION
## Description
Please explain the changes you made here.

This PR drops support for versions of node less than 14, where the following versions had the following EOL:
* Node 8 was 12/31/2019
* Node 10 was 04/30/2021
* Node 12 was 04/30/2022

Node 14 is not yet EOL, though it is upcoming, but probably good to wait a bit of time past the EOL before totally dropping it.

By raising the minimum version, we can use the following new features within the codebase:
* [async/await](https://javascript.info/async-await) (available in node 8)
* [private class features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) (available in node 12)

Closes #367 

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
