### PR TITLE
Fix image for github build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ for a few rough guidelines.
 [npm-url]: https://www.npmjs.com/package/tldr
 [npm-image]: https://img.shields.io/npm/v/tldr.svg
 [gh-actions-url]: https://github.com/tldr-pages/tldr-node-client/actions?query=workflow%3ATest+branch%3Amaster
-[gh-actions-image]: https://img.shields.io/github/workflow/status/tldr-pages/tldr-node-client/Test/master
+[gh-actions-image]: https://img.shields.io/github/actions/workflow/status/tldr-pages/tldr-node-client/test.yml?branch=master
 [dep-url]: https://david-dm.org/tldr-pages/tldr-node-client
 [dep-image]: https://david-dm.org/tldr-pages/tldr-node-client.svg?theme=shields.io
 [dev-dep-url]: https://david-dm.org/tldr-pages/tldr-node-client#info=devDependencies


### PR DESCRIPTION
## Description
Please explain the changes you made here.

PR fixes the image for the github build badge in the README so that instead of showing a link to an image in shields repo, it'll actually show the build status.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [x] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
