### PR TITLE
Fix: Download Only the files for Required Language And English as Backup | Changed the package for Unzipping

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "pagesRepository": "https://github.com/tldr-pages/tldr",
-  "repository": "https://tldr.sh/assets/tldr.zip",
+  "repositoryBase": "https://tldr.sh/assets/tldr-pages",
   "skipUpdateWhenPageNotFound": false,
   "themes": {
     "simple": {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -13,6 +13,16 @@ class Cache {
     // TODO: replace this with a private field when it reaches enough maturity
     // https://github.com/tc39/proposal-class-fields#private-fields
     this.config = config;
+
+    this.languages = ['en'];
+    // Get the primary & secondary language.
+    this.languages = this.languages.concat([
+      ...new Set(utils.localeToLang(process.env.LANG)),
+    ]);
+    this.languages = this.languages.concat([
+      ...new Set(utils.localeToLang(process.env.LANGUAGE)),
+    ]);
+
     this.cacheFolder = path.join(config.cache, 'cache');
   }
 
@@ -23,7 +33,8 @@ class Cache {
   getPage(page) {
     let preferredPlatform = platform.getPreferredPlatformFolder(this.config);
     const preferredLanguage = process.env.LANG || 'en';
-    return index.findPage(page, preferredPlatform, preferredLanguage)
+    return index
+      .findPage(page, preferredPlatform, preferredLanguage)
       .then((folder) => {
         if (!folder) {
           return;
@@ -45,30 +56,37 @@ class Cache {
     const tempFolder = path.join(os.tmpdir(), 'tldr', utils.uniqueId());
 
     // Downloading fresh copy
-    return Promise.all([
-      // Create new temporary folder
-      fs.ensureDir(tempFolder),
-      fs.ensureDir(this.cacheFolder)
-    ])
-      .then(() => {
-        // Download and extract cache data to temporary folder
-        return remote.download(tempFolder);
-      })
-      .then(() => {
-        // Copy data to cache folder
-        return fs.copy(tempFolder, this.cacheFolder);
-      })
-      .then(() => {
-        return Promise.all([
-          // Remove temporary folder
-          fs.remove(tempFolder),
-          index.rebuildPagesIndex()
-        ]);
-      })
-      // eslint-disable-next-line no-unused-vars
-      .then(([_, shortIndex]) => {
-        return shortIndex;
-      });
+    return (
+      Promise.all([
+        // Create new temporary folder
+        fs.ensureDir(tempFolder),
+        fs.ensureDir(this.cacheFolder),
+      ])
+        .then(() => {
+          // Download and extract cache data to temporary folder
+          let activeDownloads = [];
+          for (let lang of this.languages) {
+            activeDownloads.push(remote.download(tempFolder, lang));
+          }
+
+          return Promise.allSettled(activeDownloads);
+        })
+        .then(() => {
+          // Copy data to cache folder
+          return fs.copy(tempFolder, this.cacheFolder);
+        })
+        .then(() => {
+          return Promise.all([
+            // Remove temporary folder
+            fs.remove(tempFolder),
+            index.rebuildPagesIndex(),
+          ]);
+        })
+        // eslint-disable-next-line no-unused-vars
+        .then(([_, shortIndex]) => {
+          return shortIndex;
+        })
+    );
   }
 }
 

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,34 +1,40 @@
 'use strict';
 
-const unzip = require('node-unzip-2');
+const path = require('path');
+const fs = require('fs-extra');
+const unzip = require('adm-zip');
 const config = require('./config');
 const axios = require('axios');
 
 // Downloads the zip file from github and extracts it to folder
-exports.download = (path) => {
-  const url = config.get().repository;
+exports.download = (loc, lang) => {
+  // If the lang is english then keep the url simple, otherwise add language.
+  const url = config.get().repositoryBase + (lang === 'en' ? '' : '.' + lang) + '.zip';
+  const folderName = path.join(loc, 'pages' + (lang === 'en' ? '' : '.' + lang));
 
-  // Creating the extractor
-  const extractor = unzip.Extract({ path });
-
-  let req = axios({
+  return axios({
     method: 'get',
     url: url,
     responseType: 'stream',
     headers: { 'User-Agent' : 'tldr-node-client' }
   }).then(function (response) {
-    response.data.pipe(extractor);
-  });
+    return new Promise((resolve, reject) => {
+      let fileName = path.join(loc, 'download_' + lang + '.zip');
 
-  return new Promise((resolve, reject) => {
-    req.catch((err) => {
-      reject(err);
-    });
-    extractor.on('error', () => {
-      reject(new Error('Cannot update from ' + url));
-    });
-    extractor.on('close', () => {
-      resolve();
+      const writer = fs.createWriteStream(fileName);
+      response.data.pipe(writer);
+    
+      writer.on('finish', () => {
+        const zip = new unzip(fileName);
+
+        zip.extractAllTo(folderName, true);
+        fs.unlinkSync(fileName);
+        resolve();
+        
+      }).on('error', (err) => {
+        reject(err);
+      });
+      
     });
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,31 @@ module.exports = {
     return langParts[1];
   },
 
+  localeToLang(locale) {
+    if(!locale || locale.startsWith('en')) return [];
+
+    const withDialect = ['pt', 'zh'];
+    
+    let lang = locale;
+    if(lang.includes('.')) {
+      lang = lang.substring(0, lang.indexOf('.'));
+    }
+    
+    // Check for language code & country code.
+    let ll = lang, cc = '';
+    if(lang.includes('_')) {
+      cc = lang.substring(lang.indexOf('_') + 1);
+      ll = lang.substring(0, lang.indexOf('_'));
+    }
+
+    // If we have dialect for this language take dialect as well.
+    if(withDialect.indexOf(ll) !== -1 && cc !== '') {
+      return [ll, ll + '_' + cc];
+    }
+
+    return [ll];
+  },
+
   isPage(file) {
     return path.extname(file) === '.md';
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.3.8",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "axios": "^0.21.1",
         "chalk": "^4.1.0",
         "commander": "^6.1.0",
@@ -18,7 +19,6 @@
         "marked": "^4.0.10",
         "ms": "^2.1.2",
         "natural": "^2.1.5",
-        "node-unzip-2": "^0.2.8",
         "ora": "^5.1.0"
       },
       "bin": {
@@ -923,6 +923,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/afinn-165": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.3.tgz",
@@ -1214,18 +1222,6 @@
         "node": "*"
       }
     },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -1428,14 +1424,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -1504,17 +1492,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -2976,20 +2953,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3955,15 +3918,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/match-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "readable-stream": "~1.0.0"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -4552,19 +4506,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/node-unzip-2": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/node-unzip-2/-/node-unzip-2-0.2.8.tgz",
-      "integrity": "sha512-fmJi73zTRW7RSo/1wyrKc2srKMwb3L6Ppke/7elzQ0QRt6sUjfiIcVsWdrqO5uEHAdvRKXjoySuo4HYe5BB0rw==",
-      "dependencies": {
-        "binary": "~0.3.0",
-        "fstream": "~1.0.12",
-        "match-stream": "~0.0.2",
-        "pullstream": "~0.4.0",
-        "readable-stream": "~1.0.0",
-        "setimmediate": "~1.0.1"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4948,14 +4889,6 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
-    "node_modules/over": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
@@ -5320,17 +5253,6 @@
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
       "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-    },
-    "node_modules/pullstream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
-      "dependencies": {
-        "over": ">= 0.0.5 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.2 < 2",
-        "slice-stream": ">= 1.0.0 < 2"
-      }
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -5802,14 +5724,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/slice-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
-      "dependencies": {
-        "readable-stream": "~1.0.31"
       }
     },
     "node_modules/snapdragon": {
@@ -6629,14 +6543,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tslib": {
@@ -8245,6 +8151,11 @@
       "dev": true,
       "requires": {}
     },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
+    },
     "afinn-165": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.3.tgz",
@@ -8480,15 +8391,6 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
-    "binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      }
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -8674,11 +8576,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
-    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -8739,14 +8636,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": ">=0.3.0 <0.4"
-      }
     },
     "chalk": {
       "version": "4.1.0",
@@ -9932,17 +9821,6 @@
       "dev": true,
       "optional": true
     },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -10670,15 +10548,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
       "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
-    "match-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
-      "requires": {
-        "buffers": "~0.1.1",
-        "readable-stream": "~1.0.0"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11187,19 +11056,6 @@
         "process-on-spawn": "^1.0.0"
       }
     },
-    "node-unzip-2": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/node-unzip-2/-/node-unzip-2-0.2.8.tgz",
-      "integrity": "sha512-fmJi73zTRW7RSo/1wyrKc2srKMwb3L6Ppke/7elzQ0QRt6sUjfiIcVsWdrqO5uEHAdvRKXjoySuo4HYe5BB0rw==",
-      "requires": {
-        "binary": "~0.3.0",
-        "fstream": "~1.0.12",
-        "match-stream": "~0.0.2",
-        "pullstream": "~0.4.0",
-        "readable-stream": "~1.0.0",
-        "setimmediate": "~1.0.1"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11499,11 +11355,6 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
-    "over": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
-    },
     "p-limit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
@@ -11799,17 +11650,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
-      }
-    },
-    "pullstream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
-      "requires": {
-        "over": ">= 0.0.5 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.2 < 2",
-        "slice-stream": ">= 1.0.0 < 2"
       }
     },
     "pump": {
@@ -12188,14 +12028,6 @@
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
-      }
-    },
-    "slice-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
-      "requires": {
-        "readable-stream": "~1.0.31"
       }
     },
     "snapdragon": {
@@ -12878,11 +12710,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:all": "npm run lint && npm test && npm run test:functional"
   },
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
@@ -59,7 +60,6 @@
     "marked": "^4.0.10",
     "ms": "^2.1.2",
     "natural": "^2.1.5",
-    "node-unzip-2": "^0.2.8",
     "ora": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
The task at hand was to update the client so that it would only download the zip files for languages that were supported by the user system. In any case, files in english should be downloaded to act as backup. 

## Explanation of Solution
- While doing this I realized that the unzip library being used was causing issue as it was emitting the close event on extractor twice and because of it the extraction wasn't completing and some of the files were not getting extracted. Trying to resolve it I saw similiar issues on the official repo and the issue wasn't resolved. So I decided to change the npm package to unzip.
- It uses both ll & cc to download the correct zip file whenever possible.
- Is there a way to determine which languages have different version available (like pt has pt_BR, pt_PT), right now I have hard-coded the values in util.js and it will need to be updated in case other versions for other languages are added.

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
