### PR TITLE
perf: improve creating tfIdf with cache

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -88,11 +88,15 @@ let getIdf = (word) => {
 
 let createTfIdf = () => {
   corpus.tfidf = {};
+  let idfCache = {};
+
   Object.keys(corpus.fileWords).forEach((file) => {
     corpus.tfidf[file] = {};
     Object.keys(corpus.fileWords[file]).forEach((word) => {
-      let tfidf = getTf(word, file) * getIdf(word);
-      corpus.tfidf[file][word] = tfidf;
+      if(!(word in idfCache)) {
+        idfCache[word] = getIdf(word);
+      }
+      corpus.tfidf[file][word] = getTf(word, file) * idfCache[word];
     });
   });
 };


### PR DESCRIPTION
## Description
 Improve #353 

While building indexes there is a call to creating TfIdf.
I noticed that the the getIdf() method only depends on the word and doesn't the other values remained constant, so I cached the result of getIdf() for different words and before calling it again I check if I already had the value.

This improved the performance significantly. 

getTfIdf() performance:
Before: 1:52.468s. (maybe my sys is slow)
After: 9.021s

## Checklist

Please review this checklist before submitting a pull request.

- [x ] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
