### PR TITLE
feat: distinct colors for each parameter type

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -21,6 +21,12 @@ class Theme {
     this.theme = options;
   }
 
+  hasDistinctStylesForTypes() {
+    return (this.theme['exampleBool']
+      && this.theme['exampleNumber']
+      && this.theme['exampleString']);
+  }
+
   getStylingFunction(partName) {
     let styles = this.theme[partName];
     return buildStylingFunction(styles);
@@ -43,7 +49,18 @@ class Theme {
   }
 
   renderExampleToken(text) {
-    return this.getStylingFunction('exampleToken')(text);
+    let tokenName = 'exampleToken';
+    if (!this.hasDistinctStylesForTypes())
+      return this.getStylingFunction(tokenName)(text);
+
+    if (!Number.isNaN(Number(text)))
+      tokenName = 'exampleNumber';
+    if (Number.isNaN(Number(text)))
+      tokenName = 'exampleString';
+    if (/true|false/.test(text))
+      tokenName = 'exampleBool';
+
+    return this.getStylingFunction(tokenName)(text);
   }
 }
 

--- a/test/theme.spec.js
+++ b/test/theme.spec.js
@@ -86,4 +86,53 @@ describe('Theme', () => {
           chalk.white('text'));
     });
   });
+
+  describe('Rendering with distinct colors for each token type', () => {
+
+    let theme = new Theme({
+      commandName: 'greenBright, bold',
+      mainDescription: 'greenBright, bold',
+      exampleDescription: 'greenBright',
+      exampleCode: 'redBright',
+      exampleBool: 'magenta',
+      exampleNumber: 'white',
+      exampleString: 'blue'
+    });
+
+    it('should render name with greenBright and bold', () => {
+      theme.renderCommandName('text')
+        .should.equal(
+          chalk.greenBright.bold('text'));
+    });
+
+    it('should render description with greenBright and bold', () => {
+      theme.renderMainDescription('text')
+        .should.equal(
+          chalk.greenBright.bold('text'));
+    });
+
+    it('should render example description with greenBright', () => {
+      theme.renderExampleDescription('text')
+        .should.equal(
+          chalk.greenBright('text'));
+    });
+
+    it('should render example code with redBright', () => {
+      theme.renderExampleCode('text')
+        .should.equal(
+          chalk.redBright('text'));
+    });
+
+    it('should render example arguments with magenta, white, and blue, for boolean, number, and string respectively', () => {
+      theme.renderExampleToken('true')
+        .should.equal(
+          chalk.magenta('true'));
+      theme.renderExampleToken('9')
+        .should.equal(
+          chalk.white('9'));
+      theme.renderExampleToken('text')
+        .should.equal(
+          chalk.blue('text'));
+    });
+  });
 });


### PR DESCRIPTION
## Description
Implementation of the issue #397 .
In order to make it work, the theme needs to have defined the colors for `exampleNumber`, `exampleBool`, and `exampleString`. If it does not have ALL of them, the color defined for `exampleToken` will be used. 

## Checklist

Please review this checklist before submitting a pull request.

- [X] Code compiles correctly
- [X] Created tests, if possible
- [X] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
