### PR TITLE
fix: Update config.json to support type-specific example highlighting

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,35 +8,50 @@
       "mainDescription": "bold",
       "exampleDescription": "",
       "exampleCode": "",
-      "exampleToken": "underline"
+      "exampleToken": "underline",
+      "exampleNumber": "yellow, bold",
+      "exampleString": "green, italic",
+      "exampleBool": "magenta, bold"
     },
     "base16": {
       "commandName": "bold",
       "mainDescription": "",
       "exampleDescription": "green",
       "exampleCode": "red",
-      "exampleToken": "cyan"
+      "exampleToken": "cyan",
+      "exampleNumber": "yellow, bold",
+      "exampleString": "green, italic",
+      "exampleBool": "magenta, bold"
     },
     "ocean": {
       "commandName": "bold, cyan",
       "mainDescription": "",
       "exampleDescription": "green",
       "exampleCode": "cyan",
-      "exampleToken": "dim"
+      "exampleToken": "dim",
+      "exampleNumber": "yellow, bold",
+      "exampleString": "green, italic",
+      "exampleBool": "magenta, bold"
     },
     "inverse": {
       "commandName": "bold, inverse",
       "mainDescription": "inverse",
       "exampleDescription": "black",
       "exampleCode": "inverse",
-      "exampleToken": "green, bgBlack, inverse"
+      "exampleToken": "green, bgBlack, inverse",
+      "exampleNumber": "yellow, bold",
+      "exampleString": "green, italic",
+      "exampleBool": "magenta, bold"
     },
     "matrix": {
       "commandName": "bold",
       "mainDescription": "underline",
       "exampleDescription": "green, bgBlack",
       "exampleCode": "green, bgBlack",
-      "exampleToken": "green, bold, bgBlack"
+      "exampleToken": "green, bold, bgBlack",
+      "exampleNumber": "yellow, bold",
+      "exampleString": "green, italic",
+      "exampleBool": "magenta, bold"
     }
   },
   "theme": "simple"

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -53,14 +53,21 @@ class Theme {
     if (!this.hasDistinctStylesForTypes())
       return this.getStylingFunction(tokenName)(text);
 
-    if (!Number.isNaN(Number(text)))
-      tokenName = 'exampleNumber';
-    if (Number.isNaN(Number(text)))
-      tokenName = 'exampleString';
-    if (/true|false/.test(text))
-      tokenName = 'exampleBool';
+    let baseStyle = this.theme[tokenName] || '';
+    let typeStyle = '';
 
-    return this.getStylingFunction(tokenName)(text);
+    if (!Number.isNaN(Number(text)))
+      typeStyle = this.theme['exampleNumber'];
+    else if (/true|false/.test(text))
+      typeStyle = this.theme['exampleBool'];
+    else
+      typeStyle = this.theme['exampleString'];
+
+    let combinedStyle = baseStyle ?
+      baseStyle + (typeStyle ? ', ' + typeStyle : '') :
+      typeStyle;
+
+    return buildStylingFunction(combinedStyle)(text);
   }
 }
 


### PR DESCRIPTION
## Description
Fixes #397 
Follow up of the PR #444 
The feature for type-based highlighting has been implemented in the example, but themes have not been applied. You need to update `config.json` to apply type-based themes in the example.

The newly applied theme in `config.json` is a prototype.

### Before Theme Update

<img width="681" alt="before" src="https://github.com/user-attachments/assets/28f7e4c4-22f0-41cc-86de-abfcd3c46050">

### After Theme Update

<img width="681" alt="after" src="https://github.com/user-attachments/assets/b33fb969-7f32-4ee7-8ced-a5ff98ae882f">

## Checklist

Please review this checklist before submitting a pull request.

- [x] Code compiles correctly
- [ ] Created tests, if possible
- [x] All tests passing (`npm run test:all`)
- [ ] Extended the README / documentation, if necessary
