### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 permissions:
   contents: read
+  actions: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-node-client/security/code-scanning/1](https://github.com/tldr-pages/tldr-node-client/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block that grants only the minimal access the workflow needs, either at the top level of the workflow (applies to all jobs) or within the specific job. This prevents the job from inheriting potentially broader default permissions from the repository or organization.

For this particular workflow, the `build` job only checks out code, caches dependencies, sets up Node.js, and runs `npm` commands. None of these require write access to repository contents, issues, or pull requests. Therefore, we can safely restrict `GITHUB_TOKEN` to read-only access to contents by adding `permissions: contents: read`. The cleanest approach is to add this block at the workflow root (right after `name: Test` and before `on:`), which will cover all jobs; if more jobs are added later that need different permissions, they can override at the job level.

Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Test` and `on:` lines. No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
