### PR TITLE
perf: don't rebuild search corpus on every page-lookup miss

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -32,6 +32,7 @@ const platforms = require('./platforms');
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
 
 const filepath = CACHE_FOLDER + '/search-corpus.json';
+const shortIndexPath = CACHE_FOLDER + '/shortIndex.json';
 
 
 /** @type {Corpus} */
@@ -275,13 +276,65 @@ exports.createIndex = () => {
     });
 };
 
+// Returns the maximum mtime across every page file the corpus would index.
+// Walks the same glob that createIndex() uses so the staleness check matches
+// what the corpus actually covers.
+let getMaxPagesMtime = () => {
+  return utils.glob(CACHE_FOLDER + '/pages/**/*.md')
+    .then((files) => {
+      return Promise.all(files.map((f) => {
+        return fs.stat(f).catch(() => { return null; });
+      }));
+    })
+    .then((stats) => {
+      return stats.reduce((max, s) => {
+        return s && s.mtimeMs > max ? s.mtimeMs : max;
+      }, 0);
+    });
+};
+
+// Build the corpus on demand if it's missing or stale relative to the
+// pages tree. shortIndex.json is rewritten by cache.update() *after* it
+// copies pages, so its mtime is normally >= any page mtime — that gives
+// us a cheap fast path. Fall through to a full pages walk if the cheap
+// check is inconclusive (or could miss out-of-band edits to the pages
+// directory).
+let ensureCorpus = () => {
+  return Promise.all([
+    fs.stat(filepath).catch(() => { return null; }),
+    fs.stat(shortIndexPath).catch(() => { return null; }),
+  ]).then(([corpusStat, shortIndexStat]) => {
+    if (!corpusStat) {
+      return rebuildCorpus();
+    }
+    // Fast path: shortIndex untouched since corpus was written → pages
+    // can't be newer either (cache.update writes shortIndex last).
+    if (shortIndexStat && shortIndexStat.mtimeMs <= corpusStat.mtimeMs) {
+      return null;
+    }
+    // Defensive path: walk pages and compare directly.
+    return getMaxPagesMtime().then((maxPagesMtime) => {
+      if (maxPagesMtime > corpusStat.mtimeMs) {
+        return rebuildCorpus();
+      }
+      return null;
+    });
+  });
+};
+
+let rebuildCorpus = () => {
+  console.error('Building search index (this only happens on first search after a cache update)...');
+  return exports.createIndex();
+};
+
 /**
  * @param {string} rawquery
  * @returns
  */
 exports.getResults = (rawquery) => {
   query.ranks = [];
-  return readCorpus()
+  return ensureCorpus()
+    .then(() => { return readCorpus(); })
     .then(() => {
       processQuery(rawquery);
       let resultcount = 10;

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -197,9 +197,6 @@ class Tldr {
           }
           return this.cache.update()
             .then(() => {
-              return search.createIndex();
-            })
-            .then(() => {
               // And then, try to check in cache again
               return this.cache.getPage(command);
             });

--- a/test/search.spec.js
+++ b/test/search.spec.js
@@ -12,6 +12,7 @@ const index = require('../lib/index');
 
 const CACHE_FOLDER = path.join(config.get().cache, 'cache');
 const filepath = CACHE_FOLDER + '/search-corpus.json';
+const shortIndexPath = CACHE_FOLDER + '/shortIndex.json';
 
 const testData = {
   files: [{
@@ -142,6 +143,15 @@ let fakes = {
         return reject('Trying to read incorrect file path: ' + readpath);
       });
     },
+    // Pretend the on-disk corpus is newer than the shortIndex, so
+    // ensureCorpus() decides no rebuild is needed and getResults proceeds
+    // directly to readCorpus (which is mocked above).
+    stat: (statpath) => {
+      if (statpath === filepath) {
+        return Promise.resolve({mtimeMs: 2000});
+      }
+      return Promise.resolve({mtimeMs: 1000});
+    },
   },
 };
 
@@ -172,6 +182,7 @@ describe('Search', () => {
   it('should perform searches', function(t, done) {
     t.mock.method(fs, 'readFile', fakes.fs.readFile);
     t.mock.method(fs, 'writeFile', fakes.fs.writeFile);
+    t.mock.method(fs, 'stat', fakes.fs.stat);
     t.mock.method(index, 'getShortIndex', fakes.index.getShortIndex);
     search.getResults('Anthony').then((data) => {
       assert.equal(data.length, 4);
@@ -193,5 +204,66 @@ describe('Search', () => {
       assert.equal(!!error, false);
       done(error);
     });
+  });
+});
+
+describe('Lazy corpus rebuild (ensureCorpus, exercised via getResults)', () => {
+  // Helpers: fs.stat fake constructed from per-path mtimes. Any unmapped
+  // path returns the default mtime so getMaxPagesMtime sees something.
+  let statFake = (mtimes, defaultMtime) => {
+    return (p) => {
+      if (p in mtimes) {
+        return mtimes[p] === null
+          ? Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+          : Promise.resolve({ mtimeMs: mtimes[p] });
+      }
+      return Promise.resolve({ mtimeMs: defaultMtime });
+    };
+  };
+
+  it('rebuilds when corpus file is missing', async (t) => {
+    let rebuilt = false;
+    t.mock.method(fs, 'stat', statFake({ [filepath]: null, [shortIndexPath]: 1000 }, 0));
+    t.mock.method(utils, 'glob', fakes.utils.glob);
+    t.mock.method(fs, 'readFile', fakes.fs.readFile);
+    t.mock.method(fs, 'writeFile', fakes.fs.writeFile);
+    t.mock.method(search, 'createIndex', () => { rebuilt = true; return Promise.resolve(); });
+    await search.getResults('Anthony').catch(() => {});
+    assert.equal(rebuilt, true);
+  });
+
+  it('skips rebuild when corpus is newer than shortIndex (fast path)', async (t) => {
+    let rebuilt = false;
+    t.mock.method(fs, 'stat', statFake({ [filepath]: 5000, [shortIndexPath]: 1000 }, 0));
+    t.mock.method(utils, 'glob', fakes.utils.glob);
+    t.mock.method(fs, 'readFile', fakes.fs.readFile);
+    t.mock.method(search, 'createIndex', () => { rebuilt = true; return Promise.resolve(); });
+    await search.getResults('Anthony').catch(() => {});
+    assert.equal(rebuilt, false);
+  });
+
+  it('rebuilds when shortIndex is newer AND a page is newer than corpus (defensive path)', async (t) => {
+    let rebuilt = false;
+    // shortIndex newer than corpus → fast path skipped → defensive walk runs.
+    // Pages all stat as mtime 9000 (default), > corpus 5000 → rebuild.
+    t.mock.method(fs, 'stat', statFake({ [filepath]: 5000, [shortIndexPath]: 6000 }, 9000));
+    t.mock.method(utils, 'glob', fakes.utils.glob);
+    t.mock.method(fs, 'readFile', fakes.fs.readFile);
+    t.mock.method(fs, 'writeFile', fakes.fs.writeFile);
+    t.mock.method(search, 'createIndex', () => { rebuilt = true; return Promise.resolve(); });
+    await search.getResults('Anthony').catch(() => {});
+    assert.equal(rebuilt, true);
+  });
+
+  it('skips rebuild when shortIndex is newer but no page is newer than corpus (defensive path passes)', async (t) => {
+    let rebuilt = false;
+    // shortIndex newer than corpus → fast path skipped → defensive walk runs.
+    // Pages all stat as mtime 1000 (default), < corpus 5000 → no rebuild.
+    t.mock.method(fs, 'stat', statFake({ [filepath]: 5000, [shortIndexPath]: 6000 }, 1000));
+    t.mock.method(utils, 'glob', fakes.utils.glob);
+    t.mock.method(fs, 'readFile', fakes.fs.readFile);
+    t.mock.method(search, 'createIndex', () => { rebuilt = true; return Promise.resolve(); });
+    await search.getResults('Anthony').catch(() => {});
+    assert.equal(rebuilt, false);
   });
 });

--- a/test/tldr.spec.js
+++ b/test/tldr.spec.js
@@ -3,10 +3,38 @@
 const assert = require('node:assert/strict')
 const { describe, it } = require('node:test');
 const TLDR = require('../lib/tldr');
+const search = require('../lib/search');
+const { MissingPageError } = require('../lib/errors');
 
 describe('TLDR class', () => {
   it('should construct', () => {
     const tldr = new TLDR({ cache: 'some-random-string' });
     assert.equal(!!tldr, true);
+  });
+
+  it('printBestPage miss path no longer calls search.createIndex', async (t) => {
+    const tldr = new TLDR({ cache: 'some-random-string', skipUpdateWhenPageNotFound: false, pagesRepository: 'https://example.test' });
+    let updateCalled = false;
+    let createIndexCalled = false;
+    t.mock.method(tldr.cache, 'getPage', () => Promise.resolve(undefined));
+    t.mock.method(tldr.cache, 'update', () => { updateCalled = true; return Promise.resolve(); });
+    t.mock.method(search, 'createIndex', () => { createIndexCalled = true; return Promise.resolve(); });
+
+    await assert.rejects(tldr.printBestPage('definitely-not-a-real-tool'), MissingPageError);
+    assert.equal(updateCalled, true, 'cache.update should run on miss');
+    assert.equal(createIndexCalled, false, 'search.createIndex must NOT run on miss');
+  });
+
+  it('printBestPage miss path is skipped entirely when skipUpdateWhenPageNotFound is true', async (t) => {
+    const tldr = new TLDR({ cache: 'some-random-string', skipUpdateWhenPageNotFound: true, pagesRepository: 'https://example.test' });
+    let updateCalled = false;
+    let createIndexCalled = false;
+    t.mock.method(tldr.cache, 'getPage', () => Promise.resolve(undefined));
+    t.mock.method(tldr.cache, 'update', () => { updateCalled = true; return Promise.resolve(); });
+    t.mock.method(search, 'createIndex', () => { createIndexCalled = true; return Promise.resolve(); });
+
+    await assert.rejects(tldr.printBestPage('definitely-not-a-real-tool'), MissingPageError);
+    assert.equal(updateCalled, false, 'cache.update should be skipped when skipUpdateWhenPageNotFound is true');
+    assert.equal(createIndexCalled, false, 'search.createIndex should be skipped too');
   });
 });


### PR DESCRIPTION
## Description

Every page-lookup miss in `printBestPage` currently rebuilds the 30 MB `search-corpus.json` after `cache.update()` (see `lib/tldr.js`). That artifact is only ever consumed by `tldr --search`, never by a plain `tldr <name>` lookup, so the rebuild is wasted work for the overwhelmingly common case of "did I spell the command right?" misses. On a warm OS file cache (~/.tldr/cache, 7111 pages) the rebuild takes ~15 s; on a cold cache it takes ~40 s. That dominates the user-visible time of every miss.

This PR removes the eager `search.createIndex()` call from the miss path in `printBestPage` and makes the corpus build lazy inside `search.getResults()`. The corpus is rebuilt only when:

- it doesn't exist on disk, or
- the pages tree contains a file newer than the corpus.

A cheap fast path checks `shortIndex.json` first (which `cache.update()` rewrites *after* copying pages), so the expensive pages walk only runs when the cheap check is inconclusive.

The aggregate amount of corpus-building work is unchanged. It just runs at most once per cache update, on first `--search` after that update, instead of on every page-lookup miss.

### Measurements

Warm OS cache, 3 trials, `~/.tldr/cache` (7111 pages), npm-linked client, macOS:

| invocation                          | `main`     | this PR    |
|-------------------------------------|------------|------------|
| `tldr <bogus>` (page miss)          | 19.6 s     | 4.2 s      |
| `tldr --search <foo>`, corpus stale | n/a        | 16.4 s     |
| `tldr --search <foo>`, corpus fresh | n/a        | 0.5 s      |

So the hot path (page-lookup miss) is ~4.7× faster, and users who never run `--search` never pay the corpus-build cost at all.

### Implementation notes

- `lib/tldr.js`: `printBestPage` no longer chains `search.createIndex()` after `cache.update()` on a miss.
- `lib/search.js`: new `ensureCorpus()` runs at the top of `getResults()`. Fast path: if `shortIndex.json` is older than the corpus, skip. Defensive path: walk `pages/**/*.md` for max mtime; if any page is newer than the corpus (or the corpus is missing), call `createIndex()` once and print `Building search index (this only happens on first search after a cache update)...` so the wait is explained.
- The explicit `updateIndex()` action is unchanged for users who want to force a rebuild on demand.

## Checklist

- [x] Code compiles correctly
- [x] Created tests, if possible
  - 4 new tests in `test/search.spec.js` covering the lazy rebuild paths (missing corpus, fast-path skip, defensive-path rebuild, defensive-path skip).
  - 2 new tests in `test/tldr.spec.js` covering `printBestPage` miss path: confirms `search.createIndex` is no longer called, and that `skipUpdateWhenPageNotFound: true` short-circuits both `cache.update` and `search.createIndex`.
- [x] All tests passing (`npm run test:all`)
- [x] Extended the README / documentation, if necessary
  - N/A: behavior is transparent to users (still exactly as documented); only timing improves.