### PR TITLE
feat(cache): add config interval for missing pages

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "pagesRepository": "https://github.com/tldr-pages/tldr",
   "repositoryBase": "https://github.com/tldr-pages/tldr/releases/latest/download/tldr-pages",
   "skipUpdateWhenPageNotFound": false,
+  "cacheUpdateInterval": 86400000,
   "themes": {
     "simple": {
       "commandName": "bold, underline",

--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -195,13 +195,35 @@ class Tldr {
           if (this.config.skipUpdateWhenPageNotFound === true) {
             return '';
           }
-          return this.cache.update()
-            .then(() => {
-              return search.createIndex();
+          return this.cache
+            .lastUpdated()
+            .then((stats) => {
+              const interval = this.config.cacheUpdateInterval || 0;
+
+              // Don't update the cache if it was updated recently (within the interval)
+              if (Date.now() - stats.mtime < interval) {
+                return '';
+              }
+
+              return this.cache
+                .update()
+                .then(() => {
+                  return search.createIndex();
+                })
+                .then(() => {
+                  return this.cache.getPage(command);
+                });
             })
-            .then(() => {
-              // And then, try to check in cache again
-              return this.cache.getPage(command);
+            .catch(() => {
+              return this.cache
+                .update()
+                .then(() => {
+                  return search.createIndex();
+                })
+                .then(() => {
+                  // And then, try to check in cache again
+                  return this.cache.getPage(command);
+                });
             });
         }
         return content;


### PR DESCRIPTION
**Fixes #225**

## What this PR does

When a user searches for a command that does not exist, the CLI currently attempts to update the cache every time. This PR introduces a `cacheUpdateInterval` configuration to prevent unnecessary network requests when a user simply makes a typo.

## Changes

* Added `cacheUpdateInterval` to `config.json`, defaulting to 24 hours.
* Updated `printBestPage()` in `lib/tldr.js` to check `cache.lastUpdated()` against the configured interval before triggering a network update.

## How to test

1. Run `tldr --clear-cache`.
2. Run `tldr xyz`. This triggers a cache update.
3. Run `tldr xyz` again. The missing page is returned immediately without making another network request.